### PR TITLE
Image rescale has been fixed.

### DIFF
--- a/mytk/entries.py
+++ b/mytk/entries.py
@@ -45,9 +45,11 @@ class CellEntry(Base):
     def event_return_callback(self, event):
         values = self.tableview.widget.item(self.item_id).get("values")
         values[self.column_id-1] = self.value_variable.get()
-        self.tableview.widget.item(self.item_id, values=values)
+
+        self.tableview.item_modified(item_id=self.item_id, values=values)
         self.event_generate("<FocusOut>")
-        self.tableview.table_data_changed()
+        # raise NotImplementedError("Need to return change to data_source from widget")
+        # self.tableview.data_source.source_data_changed(self.tableview.data_source.records)
 
     def event_focusout_callback(self, event):
         if self.user_event_callback is not None:

--- a/mytk/entries.py
+++ b/mytk/entries.py
@@ -48,8 +48,6 @@ class CellEntry(Base):
 
         self.tableview.item_modified(item_id=self.item_id, values=values)
         self.event_generate("<FocusOut>")
-        # raise NotImplementedError("Need to return change to data_source from widget")
-        # self.tableview.data_source.source_data_changed(self.tableview.data_source.records)
 
     def event_focusout_callback(self, event):
         if self.user_event_callback is not None:

--- a/mytk/images.py
+++ b/mytk/images.py
@@ -21,7 +21,6 @@ class Image(Base):
         self.is_rescalable = False
         self.add_observer(self, "is_rescalable")
         self.resize_update_delay = 0
-        self._last_resize_event = None
         self.scheduled_resize = None
 
     def is_environment_valid(self):

--- a/mytk/tests/testImages.py
+++ b/mytk/tests/testImages.py
@@ -54,7 +54,7 @@ class TestImage(unittest.TestCase):
         img.is_rescalable = True
         img.resize_update_delay = 100
         img.grid_into(self.app.window, column=0, row=0, pady=5, padx=5, sticky="nsew")
-        self.start_timed_mainloop(timeout=50000)
+        self.start_timed_mainloop(timeout=5000)
         self.app.mainloop()
 
 

--- a/mytk/tests/testImages.py
+++ b/mytk/tests/testImages.py
@@ -1,0 +1,62 @@
+import envtest
+import unittest
+import os
+from mytk import *
+import tempfile
+import collections
+import random
+import pathlib
+
+class TestImage(unittest.TestCase):
+    def setUp(self):
+        self.app = App(geometry="500x300")
+        self.delegate_function_called = False
+        self.resource_directory = pathlib.Path(__file__).parent.parent / "resources"
+
+    def tearDown(self):
+        self.app.quit()
+
+    def start_timed_mainloop(self, function=None, timeout=500):
+        if function is not None:
+            self.app.root.after(int(timeout/4), function)
+        self.app.root.after(timeout, self.app.quit) # max 5 seconds
+
+    def test_init_empty(self):
+        self.assertIsNotNone(Image())
+
+    def test_resource_directory(self):
+        resource_directory = pathlib.Path(__file__).parent.parent / "resources"
+        self.assertEqual(resource_directory, pathlib.Path("/Users/dccote/GitHub/myTk/mytk/resources"))
+
+    def test_init_with_path(self):
+        self.assertIsNotNone(Image(filepath= self.resource_directory / "error.png"))
+
+    def test_init_with_url(self):
+        self.assertIsNotNone(Image(url="http://www.dcclab.ca/wp-content/uploads/2020/09/logo_4_horizontal-1.png"))
+
+    def test_into_window(self):
+        img = Image(self.resource_directory / "error.png")
+        img.grid_into(self.app.window, column=0, row=0, pady=5, padx=5, sticky="")
+        self.start_timed_mainloop(timeout=500)
+        self.app.mainloop()
+
+    def test_rescalable_no_delay(self):
+        self.app.window.all_resize_weight(1)
+        img = Image(self.resource_directory / "error.png")
+        img.grid_into(self.app.window, column=0, row=0, pady=5, padx=5, sticky="nsew")
+        img.is_rescalable = True
+        self.start_timed_mainloop(timeout=5000)
+        self.app.mainloop()
+
+    def test_rescalable_with_delay(self):
+        self.app.window.all_resize_weight(1)
+        img = Image(self.resource_directory / "error.png")
+        img.is_rescalable = True
+        img.resize_update_delay = 100
+        img.grid_into(self.app.window, column=0, row=0, pady=5, padx=5, sticky="nsew")
+        self.start_timed_mainloop(timeout=50000)
+        self.app.mainloop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mytk/tests/testTableView.py
+++ b/mytk/tests/testTableView.py
@@ -234,16 +234,19 @@ class TestTableview(unittest.TestCase):
 
         self.app.mainloop()
 
-    def test_impossible_to_change_column(self):
+    def test_impossible_to_change_column_after_setting_them(self):
         self.tableview = TableView({"a":"Column A","b":"Column B"})
         self.tableview.grid_into(self.app.window)
 
         with self.assertRaises(Exception):
             self.tableview.widget["columns"] = ("c","d","e")
 
+        with self.assertRaises(Exception):
+            self.widget.configure(columns=("c","d","e"))
+
     def add_change(self):
         record = self.tableview.data_source.append_record({"a":"value a","b":"value b"})
-        iinfo = self.tableview.widget.item(record["__uuid"], values=["new value a","new value b"])
+        iinfo = self.tableview.item_modified(record["__uuid"], values=["new value a","new value b"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The automatic rescaling of an image has been fixed: when active, it will rescale the image to exactly the size of the widget.  This should avoid the infinite loop where an image is scaled up, then the grid responds by scaling itself up more, which triggers a rescaling of the image etc....  Nevertheless, the delayed_update has been kept just in case.

The strategy for the delayed_update has been changed and may not be optimal: before, the udpate_display() command would simply not be called more often than a given delay.  Now, instead, we schedule a delay with tk.after() and keep track if an update has already been scheduled to avoid overwriting it.  This is not optimal because if the user holds the mouse button for a long time (longer than the delay) the scheduled command with after() is not run before the mouse button is let go.

