### PR TITLE
Added scheduling on maint thread with a is_main_thread function

### DIFF
--- a/mytk/app.py
+++ b/mytk/app.py
@@ -28,6 +28,7 @@ import os
 import subprocess
 from contextlib import redirect_stdout, suppress
 import io
+from queue import Queue as TQueue, Empty, Full
 from tkinter import Menu, TclError
 
 from .modulesmanager import ModulesManager
@@ -35,6 +36,7 @@ from .bindable import Bindable
 from .window import Window
 from .dialog import Dialog
 from .eventcapable import EventCapable
+from .utils import is_main_thread
 
 
 class App(Bindable, EventCapable):
@@ -72,10 +74,14 @@ class App(Bindable, EventCapable):
         self.name = name
         self.help_url = help_url
         self.window = Window(geometry=geometry, title=name)
+        self.main_queue: TQueue = TQueue()
+        self.run_loop_delay: int = 20
+
         self.check_requirements()
         self.create_menu()
 
         App.app = self
+        self.after(self.run_loop_delay, self.run_main_queue)
 
     @property
     def widget(self):
@@ -125,7 +131,28 @@ class App(Bindable, EventCapable):
         """
         Enters the Tkinter main event loop.
         """
+        self.run_main_queue()
         self.window.widget.mainloop()
+
+    def schedule_on_main_thread(self, fct, args=None, kwargs=None):
+        self.main_queue.put((fct, args, kwargs))
+
+    def run_main_queue(self):
+        assert is_main_thread()
+
+        while not self.main_queue.empty():
+            try:
+                f, args, kwargs = self.main_queue.get_nowait()
+                f(*(args or []), **(kwargs or {}))
+            except Empty:
+                pass
+            except Exception as e:
+                print(
+                    "Unable to call scheduled function {fct} with arguments {args}:",
+                    e,
+                )
+
+        self.after(self.run_loop_delay, self.run_main_queue)
 
     def create_menu(self):
         """

--- a/mytk/utils.py
+++ b/mytk/utils.py
@@ -1,3 +1,10 @@
+from threading import current_thread, main_thread
+
+
+def is_main_thread() -> bool:
+    return current_thread() == main_thread()
+
+
 def package_app_script(filepath=None):
     from inspect import currentframe, getframeinfo
 


### PR DESCRIPTION
UI-related calls must be on the main thread.  Calling `root.after()` is not sufficient to schedule on the mainloop and main thread, youn really need to transfer the control to the main thread.  The only solution I found was to use a main_queue (`Threading.queue`) and put (fct, args, kwargs) on it, then go through the queue at regular interval (on the main thread in the mainloop) and call the methods when required.