### PR TITLE
Fix bugs in TabularData, TableView, FileViewer and hanging tests

### DIFF
--- a/mytk/fileviewer.py
+++ b/mytk/fileviewer.py
@@ -163,11 +163,6 @@ class FileViewer(TableView):
         super().__init__(
             columns_labels=columns_labels, is_treetable=True, create_data_source=False
         )
-        self.data_source = FileTreeData(
-            root_dir=root_dir,
-            tableview=self,
-            required_fields=list(columns_labels.keys()),
-        )
         self.column_formats = {
             "size": {
                 "format_string": r"{0:.1f}k",
@@ -180,6 +175,12 @@ class FileViewer(TableView):
         self.default_format_string = "{0}"
         self.all_elements_are_editable = False
         self.hide_system_files = True
+
+        self.data_source = FileTreeData(
+            root_dir=root_dir,
+            tableview=self,
+            required_fields=list(columns_labels.keys()),
+        )
 
     def source_data_changed(self, records):
         """Update the widget, optionally filtering out system files."""

--- a/mytk/tableview.py
+++ b/mytk/tableview.py
@@ -81,8 +81,12 @@ class TableView(Base):
 
     @displaycolumns.setter
     def displaycolumns(self, values):
+        if self.widget is None:
+            return
+
         if isinstance(values, Iterable) and len(values) == 0:
-            print('Warning: empty displaycolumns will display nothing')
+            import warnings
+            warnings.warn("empty displaycolumns will display nothing", stacklevel=2)
 
         self.widget.configure(displaycolumns=values)
 
@@ -101,7 +105,10 @@ class TableView(Base):
 
     @headings.setter
     def headings(self, new_values):
-        assert len(new_values) == len(self.columns)
+        if len(new_values) != len(self.columns):
+            raise ValueError(
+                f"Expected {len(self.columns)} headings, got {len(new_values)}"
+            )
         new_columns_labels = dict(zip(self.columns, new_values, strict=False))
 
         if self.widget is not None:
@@ -124,7 +131,7 @@ class TableView(Base):
             self.columns = list(new_values.keys())
             self.headings = list(new_values.values())
         else:
-            return self._columns_labels
+            self._columns_labels = new_values
 
     def heading_info(self, cid):
         """Return heading configuration info for the given column identifier."""
@@ -158,8 +165,8 @@ class TableView(Base):
                 takefocus=True,
             )
 
-        self.widget.configure(columns=sorted(list(self._columns_labels.keys())))
-        self.widget.configure(displaycolumns=sorted(list(self._columns_labels.keys())))
+        self.widget.configure(columns=list(self._columns_labels.keys()))
+        self.widget.configure(displaycolumns=list(self._columns_labels.keys()))
         for key, value in self._columns_labels.items():
             self.widget.heading(key, text=value)
 
@@ -172,9 +179,8 @@ class TableView(Base):
         self.source_data_added_or_updated(records)
         self.source_data_deleted(records)
 
-        if self.delegate is not None:
-            with suppress(AttributeError):
-                self.delegate.source_data_changed(self)
+        if self.delegate is not None and hasattr(self.delegate, "source_data_changed"):
+            self.delegate.source_data_changed(self)
 
     def source_data_added_or_updated(self, records):
         """Insert new records or update existing ones in the widget."""
@@ -207,7 +213,7 @@ class TableView(Base):
             padding = ""
             column_name = self.columns[i]
             if len(self.displaycolumns) > 0 and column_name == self.displaycolumns[0]:
-                level = record.get("depth_level", 0)
+                level = record.get("__depth_level", 0)
                 padding = "   " * level
 
             column_format = self.column_formats.get(column_name, None)
@@ -277,13 +283,13 @@ class TableView(Base):
 
     def empty(self):
         """Remove all items from the table."""
-        self.clear_widget_content()
+        if self.data_source is not None:
+            self.data_source.remove_all_records()
 
     def selection_changed(self, event):
         """Notify the delegate when the table selection changes."""
-        if self.delegate is not None:
-            with suppress(AttributeError):
-                self.delegate.selection_changed(event, self)
+        if self.delegate is not None and hasattr(self.delegate, "selection_changed"):
+            self.delegate.selection_changed(event, self)
 
     def identify_column_name(self, event_x):
         """Return the column name at the given x pixel coordinate."""
@@ -327,11 +333,11 @@ class TableView(Base):
     def click(self, event) -> bool:  # pragma: no cover
         """Handle a single click event on the table."""
         keep_running = True
-        try:
-            with suppress(AttributeError):
+        if self.delegate is not None and hasattr(self.delegate, "click"):
+            try:
                 keep_running = self.delegate.click(event, self)
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+            except Exception as err:
+                raise TableView.DelegateError(err) from err
 
         if keep_running:
             region = self.widget.identify_region(event.x, event.y)
@@ -352,13 +358,13 @@ class TableView(Base):
         item_dict = self.widget.item(item_id)
 
         keep_running = True
-        try:
-            with suppress(AttributeError):
+        if self.delegate is not None and hasattr(self.delegate, "click_cell"):
+            try:
                 keep_running = self.delegate.click_cell(
                     item_id, column_name, self
                 )
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+            except Exception as err:
+                raise TableView.DelegateError(err) from err
 
         if keep_running:
             logical_column_id = self.get_logical_column_id(column_name)
@@ -422,13 +428,13 @@ class TableView(Base):
         keep_running = True
 
         if column_name not in self.columns:
-            raise ValueError(f"click_header: '{column_name}'' is not the name of a column")
+            raise ValueError(f"click_header: '{column_name}' is not the name of a column")
 
-        try:
-            with suppress(AttributeError):
+        if self.delegate is not None and hasattr(self.delegate, "click_header"):
+            try:
                 keep_running = self.delegate.click_header(column_name, self)
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+            except Exception as err:
+                raise TableView.DelegateError(err) from err
 
         if keep_running:
             with suppress(IndexError):  # if empty, not an error
@@ -442,11 +448,11 @@ class TableView(Base):
     def doubleclick(self, event) -> bool:  # pragma: no cover
         """Handle a double-click event on the table."""
         keep_running = True
-        try:
-            with suppress(AttributeError):
+        if self.delegate is not None and hasattr(self.delegate, "doubleclick"):
+            try:
                 keep_running = self.delegate.doubleclick(event, self)
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+            except Exception as err:
+                raise TableView.DelegateError(err) from err
 
         if keep_running:
             region = self.widget.identify_region(event.x, event.y)
@@ -474,13 +480,11 @@ class TableView(Base):
         else:
             _keep_running = True
 
-        try:
-            with suppress(AttributeError):
-                _keep_running = self.delegate.doubleclick_cell(
-                    item_id, column_name, self
-                )
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+        if self.delegate is not None and hasattr(self.delegate, "doubleclick_cell"):
+            try:
+                self.delegate.doubleclick_cell(item_id, column_name, self)
+            except Exception as err:
+                raise TableView.DelegateError(err) from err
 
     def focus_edit_cell(self, item_id, column_name):
         """Place an entry widget over the cell for inline editing."""
@@ -501,9 +505,8 @@ class TableView(Base):
         """Handle a double-click on a column header."""
         assert isinstance(column_name, str)
 
-        _keep_running = True
-        try:
-            with suppress(AttributeError):
-                _keep_running = self.delegate.doubleclick_header(column_name, self)
-        except Exception as err:
-            raise TableView.DelegateError(err) from err
+        if self.delegate is not None and hasattr(self.delegate, "doubleclick_header"):
+            try:
+                self.delegate.doubleclick_header(column_name, self)
+            except Exception as err:
+                raise TableView.DelegateError(err) from err

--- a/mytk/tableview.py
+++ b/mytk/tableview.py
@@ -176,6 +176,9 @@ class TableView(Base):
 
     def source_data_changed(self, records):
         """Update the widget to reflect changes in the data source records."""
+        if self.widget is None:
+            return
+
         self.source_data_added_or_updated(records)
         self.source_data_deleted(records)
 

--- a/mytk/tabulardata.py
+++ b/mytk/tabulardata.py
@@ -2,7 +2,6 @@ import collections
 import json
 import uuid
 import weakref
-from contextlib import suppress
 from pathlib import Path
 
 from .bindable import Bindable
@@ -158,9 +157,7 @@ class TabularData(Bindable):
 
     def remove_record(self, index_or_uuid):
         """Remove and return the record at the given index or with the given UUID."""
-        index = index_or_uuid
-        if isinstance(index_or_uuid, str):
-            index = self.field("__uuid").index(index_or_uuid)
+        index = self._resolve_index(index_or_uuid)
 
         record = self.records.pop(index)
         self.source_records_changed()
@@ -204,6 +201,9 @@ class TabularData(Bindable):
                             f"record has extra field: {field_name}"
                         )
         for field_name in self.record_fields():
+            if field_name not in record:
+                continue
+
             field_properties = self.get_field_properties(field_name)
             field_type = field_properties.get('type', None)
 
@@ -212,8 +212,6 @@ class TabularData(Bindable):
                     record[field_name] = field_type(record[field_name])
                 except (ValueError, TypeError):
                     record[field_name] = None
-            else:
-                pass # Leave as-is
 
         return record
 
@@ -264,12 +262,16 @@ class TabularData(Bindable):
 
         index = self._resolve_index(index_or_uuid)
 
-        if self.records[index] != values:
+        if any(self.records[index].get(k) != v for k, v in values.items()):
             self.records[index].update(values)
             self.source_records_changed()
 
     def update_field(self, name, values):
         """Update a field across all records with the given list of values."""
+        if len(values) != len(self.records):
+            raise ValueError(
+                f"Expected {len(self.records)} values, got {len(values)}"
+            )
         for i, value in enumerate(values):
             self.records[i][name] = value
         self.source_records_changed()
@@ -322,12 +324,13 @@ class TabularData(Bindable):
 
     def rename_field(self, old_name, new_name):
         """Rename a field across all records."""
+        if old_name not in self.record_fields():
+            raise RuntimeError("field does not exist")
         if new_name in self.record_fields():
             raise RuntimeError("Name already used")
 
         for record in self.records:
-            record[new_name] = record[old_name]
-            record.pop(old_name, None)
+            record[new_name] = record.pop(old_name, None)
         self.source_records_changed()
 
     def sorted_records_uuids(self, field, only_uuids=None, reverse=False):
@@ -347,11 +350,14 @@ class TabularData(Bindable):
     def source_records_changed(self, changed_records=None):
         """Notify the delegate that records have changed."""
         if not self._disable_change_calls and self.delegate is not None:
-            with suppress(AttributeError):
-                if changed_records is None:
-                    changed_records = self.ordered_records()
+            delegate = self.delegate()
+            if delegate is None or not hasattr(delegate, "source_data_changed"):
+                return
 
-                self.delegate().source_data_changed(changed_records)
+            if changed_records is None:
+                changed_records = self.ordered_records()
+
+            delegate.source_data_changed(changed_records)
 
     def load(self, filepath):
         """Load records from a JSON file and insert them into the data source."""

--- a/mytk/tests/testTableView.py
+++ b/mytk/tests/testTableView.py
@@ -326,7 +326,7 @@ class TestTableview(envtest.MyTkTestCase):
 
         self.tableview.columns = ('c','d')
         self.assertEqual(self.tableview.columns_labels, {"c": "", "d": ""})
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.tableview.headings = ('Column C','Column D','Extra column')
         self.assertEqual(self.tableview.columns_labels, {"c": "", "d": ""})
 

--- a/mytk/tests/testTabularData.py
+++ b/mytk/tests/testTabularData.py
@@ -524,6 +524,79 @@ class TestTabularDataRecordOps(unittest.TestCase):
         t = TabularData(tableview=tv)
         self.assertIsNotNone(t.delegate)
 
+    def test_remove_record_by_uuid_object(self):
+        t = TabularData()
+        r1 = t.append_record({"a": 1})
+        r2 = t.append_record({"a": 2})
+        uid_obj = uuid.UUID(r1["__uuid"])
+        t.remove_record(uid_obj)
+        self.assertEqual(t.record_count, 1)
+        self.assertEqual(t.records[0]["a"], 2)
+
+    def test_rename_field_old_name_missing(self):
+        t = TabularData()
+        t.append_record({"a": 1})
+        with self.assertRaises(RuntimeError):
+            t.rename_field("nonexistent", "b")
+
+    def test_normalize_record_skips_missing_typed_field(self):
+        t = TabularData()
+        t.update_field_properties("score", {"type": float})
+        t.append_record({"score": 1.0})  # seed so record_fields() includes "score"
+        # Insert a record without "score" — should not raise KeyError
+        record = t.append_record({"name": "Alice"})
+        self.assertNotIn("score", record)
+
+    def test_delegate_attribute_error_propagates(self):
+        class BuggyDelegate:
+            def source_data_changed(self, records):
+                raise AttributeError("bug inside delegate")
+
+        delegate = BuggyDelegate()  # prevent garbage collection
+        t = TabularData(delegate=delegate)
+        with self.assertRaises(AttributeError):
+            t.append_record({"a": 1})
+
+    def test_update_record_no_change_skips_notification(self):
+        call_count = 0
+
+        class CountingDelegate:
+            def source_data_changed(self, records):
+                nonlocal call_count
+                call_count += 1
+
+        t = TabularData(delegate=CountingDelegate())
+        t.append_record({"a": 1})
+        count_after_insert = call_count
+        # Update with same value — should not fire notification
+        t.update_record(0, {"a": 1})
+        self.assertEqual(call_count, count_after_insert)
+
+    def test_update_field_length_mismatch(self):
+        t = TabularData()
+        t.append_record({"a": 1})
+        t.append_record({"a": 2})
+        with self.assertRaises(ValueError):
+            t.update_field("a", [10])  # too short
+        with self.assertRaises(ValueError):
+            t.update_field("a", [10, 20, 30])  # too long
+
+    def test_update_record_partial_no_change(self):
+        t = TabularData()
+        t.append_record({"a": 1, "b": 2})
+        # Partial update with same value for "a"
+        call_count = 0
+        class CountingDelegate:
+            def source_data_changed(self, records):
+                nonlocal call_count
+                call_count += 1
+        t.delegate = __import__("weakref").ref(CountingDelegate())
+        # Need to keep delegate alive
+        delegate = CountingDelegate()
+        t.delegate = __import__("weakref").ref(delegate)
+        t.update_record(0, {"a": 1})
+        self.assertEqual(call_count, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mytk/tests/testTreeTableView.py
+++ b/mytk/tests/testTreeTableView.py
@@ -7,6 +7,7 @@ import envtest
 
 from mytk import *
 from mytk.fileviewer import FileRecord
+from mytk.tabulardata import PostponeChangeCalls
 
 
 class TestTreeTableview(envtest.MyTkTestCase):
@@ -58,49 +59,51 @@ class TestTreeTableview(envtest.MyTkTestCase):
         self.tableview.widget.after(100, self.app.quit)
         self.app.mainloop()
 
-    def fill_tabular_data_with_fileviewer_data(self, t, dir):
-        for parent_path, dirs, files in os.walk(dir):
-            pid = None
-            for record in t.records:
-                if record["fullpath"] == parent_path:
-                    pid = record["__uuid"]
+    def fill_tabular_data_with_fileviewer_data(self, t, dir, max_depth=1):
+        with PostponeChangeCalls(t):
+            for depth, (parent_path, dirs, files) in enumerate(os.walk(dir)):
+                if depth >= max_depth:
                     break
 
-            for filename in files:
-                filepath = Path(parent_path) / filename
-                size = filepath.stat().st_size
-                mdate = filepath.stat().st_mtime
-                mdate = time.strftime(
-                    "%m/%d/%Y", time.gmtime(filepath.stat().st_mtime)
-                )
-                _ = t.insert_record(
-                    pid=pid,
-                    index=None,
-                    values={
-                        "name": filename,
-                        "size": "{0:.1f} k".format(size / 1000),
-                        "date_modified": mdate,
-                        "fullpath": filepath,
-                    },
-                )
+                pid = None
+                for record in t.records:
+                    if record["fullpath"] == parent_path:
+                        pid = record["__uuid"]
+                        break
 
-            for directory in dirs:
-                directorypath = Path(parent_path) / directory
-                size = directorypath.stat().st_size
-                mdate = directorypath.stat().st_mtime
-                mdate = time.strftime(
-                    "%m/%d/%Y", time.gmtime(directorypath.stat().st_mtime)
-                )
-                _ = t.insert_record(
-                    pid=pid,
-                    index=None,
-                    values={
-                        "name": directory,
-                        "size": "",
-                        "date_modified": mdate,
-                        "fullpath": directorypath,
-                    },
-                )
+                for filename in files:
+                    filepath = Path(parent_path) / filename
+                    size = filepath.stat().st_size
+                    mdate = time.strftime(
+                        "%m/%d/%Y", time.gmtime(filepath.stat().st_mtime)
+                    )
+                    _ = t.insert_record(
+                        pid=pid,
+                        index=None,
+                        values={
+                            "name": filename,
+                            "size": "{0:.1f} k".format(size / 1000),
+                            "date_modified": mdate,
+                            "fullpath": filepath,
+                        },
+                    )
+
+                for directory in dirs:
+                    directorypath = Path(parent_path) / directory
+                    size = directorypath.stat().st_size
+                    mdate = time.strftime(
+                        "%m/%d/%Y", time.gmtime(directorypath.stat().st_mtime)
+                    )
+                    _ = t.insert_record(
+                        pid=pid,
+                        index=None,
+                        values={
+                            "name": directory,
+                            "size": "",
+                            "date_modified": mdate,
+                            "fullpath": directorypath,
+                        },
+                    )
 
     def test_show_filesview(self):
         self.app.window.widget.grid_rowconfigure(0, weight=1)


### PR DESCRIPTION
## Summary

### TabularData — 6 bug fixes
- **`remove_record`** now uses `_resolve_index()` so `uuid.UUID` objects work consistently
- **`rename_field`** validates that `old_name` exists before modifying records
- **`_normalize_record`** skips type conversion for fields the record doesn't have (prevents `KeyError`)
- **`source_records_changed`** replaces `suppress(AttributeError)` with explicit `hasattr` check so real delegate errors propagate
- **`update_record`** comparison now checks only the supplied keys, correctly detecting no-op partial updates
- **`update_field`** validates `len(values) == len(records)`, raising `ValueError` on mismatch
- 7 new tests added (71 total TabularData tests)

### TableView — 8 bug fixes
- **`__depth_level`** key fixed (was `depth_level`, never matched TabularData)
- **`empty()`** now clears `data_source.remove_all_records()` instead of just the widget
- **`columns_labels.setter`** stores value before widget creation (was dead `return`)
- **`displaycolumns.setter`** guards against `None` widget
- **8x `suppress(AttributeError)`** replaced with `hasattr` checks on delegates
- **`create_widget`** preserves insertion order (removed incorrect `sorted()`)
- **Typo** fixed in `click_header` error message
- **`assert`** replaced with `raise ValueError` in `headings.setter`

### FileViewer — init ordering + widget guard
- Moved `hide_system_files`, `column_formats`, etc. **before** `FileTreeData()` creation so they exist when `source_data_changed` is called during init
- Added `if self.widget is None: return` guard in `TableView.source_data_changed` to handle calls before widget creation
- These two fixes resolved 3 previously failing TreeTableView tests

### Hanging test fix
- `test_show_files_tableview` hung because `os.walk(".")` traversed **16,839 files**, each `insert_record` triggering an O(n²) widget rebuild
- Fixed by wrapping inserts in `PostponeChangeCalls` (single widget update) and limiting walk to top-level directory
- All 9 TreeTableView tests now pass in ~1.5s

## Test results
- **388 passed**, 4 skipped, 0 failures (full test suite in ~40s)

## Test plan
- [x] All 71 TabularData tests pass
- [x] All 59 TableView tests pass
- [x] All 9 TreeTableView tests pass (previously 3 failed + 6 hung)
- [x] Full suite: 388 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)