### PR TITLE
Add JSONCanvas viewer for JSON Canvas 1.0

### DIFF
--- a/mytk/__init__.py
+++ b/mytk/__init__.py
@@ -10,6 +10,7 @@ from .base import Base
 from .bindable import Bindable
 from .button import Button
 from .canvasview import CanvasView
+from .jsoncanvas import JSONCanvas
 from .checkbox import Checkbox
 from .configurable import (
     ConfigModel,

--- a/mytk/example_apps/jsoncanvas_app.py
+++ b/mytk/example_apps/jsoncanvas_app.py
@@ -1,0 +1,73 @@
+"""
+jsoncanvas_app.py — Minimal viewer for JSON Canvas 1.0 documents.
+
+Loads a built-in sample on startup. Click "Load…" to open a `.canvas` or
+`.json` file that follows the JSON Canvas 1.0 spec.
+"""
+
+from tkinter import filedialog
+
+
+SAMPLE_DOCUMENT = {
+    "nodes": [
+        {"id": "group",  "type": "group", "x": -40, "y": -40,
+         "width": 740, "height": 400, "label": "Demo group", "color": "5"},
+        {"id": "intro",  "type": "text", "x": 20, "y": 20,
+         "width": 200, "height": 80, "text": "JSON Canvas 1.0\nviewer", "color": "4"},
+        {"id": "readme", "type": "file", "x": 260, "y": 20,
+         "width": 200, "height": 80, "file": "README.md", "subpath": "#overview"},
+        {"id": "site",   "type": "link", "x": 500, "y": 20,
+         "width": 200, "height": 80, "url": "https://jsoncanvas.org"},
+        {"id": "note",   "type": "text", "x": 260, "y": 200,
+         "width": 200, "height": 100,
+         "text": "Edges connect sides.\nArrowheads follow toEnd.",
+         "color": "3"},
+    ],
+    "edges": [
+        {"id": "e1", "fromNode": "intro",  "toNode": "readme",
+         "fromSide": "right", "toSide": "left", "label": "points to"},
+        {"id": "e2", "fromNode": "readme", "toNode": "site",
+         "fromSide": "right", "toSide": "left"},
+        {"id": "e3", "fromNode": "readme", "toNode": "note",
+         "fromSide": "bottom", "toSide": "top", "color": "1"},
+        {"id": "e4", "fromNode": "intro", "toNode": "note",
+         "fromEnd": "arrow", "toEnd": "arrow", "color": "6"},
+    ],
+}
+
+
+if __name__ == "__main__":
+    from mytk import App, Button, JSONCanvas
+
+    app = App(bring_to_front=True)
+    app.window.widget.title("JSON Canvas viewer")
+
+    canvas = JSONCanvas(width=800, height=500)
+    canvas.grid_into(app.window, row=0, column=0, columnspan=2,
+                     padx=10, pady=10, sticky="nsew")
+
+    def load_file():
+        path = filedialog.askopenfilename(
+            title="Open a JSON Canvas file",
+            filetypes=[("JSON Canvas", "*.canvas *.json"), ("All files", "*.*")],
+        )
+        if path:
+            canvas.load_from_file(path)
+
+    def load_sample():
+        canvas.load(SAMPLE_DOCUMENT)
+
+    Button("Load\u2026", user_event_callback=lambda e, b: load_file()).grid_into(
+        app.window, row=1, column=0, padx=10, pady=(0, 10), sticky="w"
+    )
+    Button("Reload sample",
+           user_event_callback=lambda e, b: load_sample()).grid_into(
+        app.window, row=1, column=1, padx=10, pady=(0, 10), sticky="e"
+    )
+
+    app.window.row_resize_weight(0, 1)
+    app.window.column_resize_weight(0, 1)
+    app.window.column_resize_weight(1, 1)
+
+    load_sample()
+    app.mainloop()

--- a/mytk/jsoncanvas.py
+++ b/mytk/jsoncanvas.py
@@ -1,0 +1,275 @@
+"""Viewer for JSON Canvas 1.0 documents (https://jsoncanvas.org/spec/1.0/)."""
+import json
+import os
+
+from .canvasview import CanvasView
+
+
+PRESET_COLORS = {
+    "1": "#e74c3c",
+    "2": "#e67e22",
+    "3": "#f1c40f",
+    "4": "#27ae60",
+    "5": "#3498db",
+    "6": "#9b59b6",
+}
+
+DEFAULT_NODE_FILL = "#ffffff"
+DEFAULT_NODE_OUTLINE = "#606060"
+DEFAULT_EDGE_COLOR = "#606060"
+DEFAULT_TEXT_COLOR = "#202020"
+GROUP_FILL = ""
+GROUP_OUTLINE = "#808080"
+CORNER_RADIUS = 10
+
+
+class JSONCanvas(CanvasView):
+    """Render a JSON Canvas 1.0 document on a Tk canvas.
+
+    Usage:
+        canvas = JSONCanvas(width=800, height=600)
+        canvas.grid_into(parent, ...)
+        canvas.load(document_dict)
+        # or: canvas.load_from_file("example.canvas")
+    """
+
+    def __init__(self, width=800, height=600, **kwargs):
+        super().__init__(width=width, height=height, **kwargs)
+        self._data = None
+
+    def load(self, data):
+        """Render the supplied JSON Canvas document (a dict)."""
+        self._data = data
+        if self.widget is not None:
+            self._render()
+
+    def load_from_file(self, filepath):
+        """Load and render a .canvas / .json file from disk."""
+        with open(filepath, encoding="utf-8") as f:
+            self.load(json.load(f))
+
+    def create_widget(self, master, **kwargs):
+        super().create_widget(master, **kwargs)
+        if self._data is not None:
+            self._render()
+
+    def _render(self):
+        self.widget.delete("all")
+
+        nodes = list(self._data.get("nodes", []))
+        edges = list(self._data.get("edges", []))
+        nodes_by_id = {n["id"]: n for n in nodes}
+
+        self._set_scrollregion(nodes)
+
+        for edge in edges:
+            self._draw_edge(edge, nodes_by_id)
+
+        for node in nodes:
+            self._draw_node(node)
+
+    def _set_scrollregion(self, nodes):
+        if not nodes:
+            self.widget.configure(scrollregion=(0, 0, 0, 0))
+            return
+        margin = 40
+        x1 = min(n["x"] for n in nodes) - margin
+        y1 = min(n["y"] for n in nodes) - margin
+        x2 = max(n["x"] + n["width"] for n in nodes) + margin
+        y2 = max(n["y"] + n["height"] for n in nodes) + margin
+        self.widget.configure(scrollregion=(x1, y1, x2, y2))
+
+    @staticmethod
+    def resolve_color(value, default):
+        if value is None:
+            return default
+        if isinstance(value, str) and value in PRESET_COLORS:
+            return PRESET_COLORS[value]
+        return value
+
+    def _create_round_rect(self, x, y, w, h, radius=CORNER_RADIUS, **kwargs):
+        """Draw a rounded rectangle via a smoothed polygon.
+
+        Uses the classic 12-point + smooth=True trick: doubled corner anchors
+        act as Bezier control points, producing visually clean rounded corners
+        without real arcs.
+        """
+        r = min(radius, w / 2, h / 2)
+        x1, y1, x2, y2 = x, y, x + w, y + h
+        points = (
+            x1 + r, y1,
+            x2 - r, y1,
+            x2, y1,
+            x2, y1 + r,
+            x2, y2 - r,
+            x2, y2,
+            x2 - r, y2,
+            x1 + r, y2,
+            x1, y2,
+            x1, y2 - r,
+            x1, y1 + r,
+            x1, y1,
+        )
+        return self.widget.create_polygon(points, smooth=True, **kwargs)
+
+    def _draw_node(self, node):
+        node_type = node.get("type")
+        if node_type == "group":
+            return self._draw_group(node)
+        if node_type == "text":
+            return self._draw_text_node(node)
+        if node_type == "file":
+            return self._draw_file_node(node)
+        if node_type == "link":
+            return self._draw_link_node(node)
+        return self._draw_generic_rect(node)
+
+    def _draw_generic_rect(self, node):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        outline = self.resolve_color(node.get("color"), DEFAULT_NODE_OUTLINE)
+        self._create_round_rect(
+            x, y, w, h,
+            fill=DEFAULT_NODE_FILL, outline=outline, width=2,
+        )
+
+    def _draw_group(self, node):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        outline = self.resolve_color(node.get("color"), GROUP_OUTLINE)
+        self._create_round_rect(
+            x, y, w, h,
+            fill=GROUP_FILL, outline=outline, width=2, dash=(6, 4),
+        )
+        label = node.get("label")
+        if label:
+            self.widget.create_text(
+                x + 8, y + 8,
+                text=label, anchor="nw",
+                fill=outline,
+                font=("Helvetica", 11, "bold"),
+            )
+
+    def _draw_text_node(self, node):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        outline = self.resolve_color(node.get("color"), DEFAULT_NODE_OUTLINE)
+        self._create_round_rect(
+            x, y, w, h,
+            fill=DEFAULT_NODE_FILL, outline=outline, width=2,
+        )
+        text = node.get("text", "")
+        self.widget.create_text(
+            x + 10, y + 10,
+            text=text, anchor="nw",
+            width=max(w - 20, 1),
+            fill=DEFAULT_TEXT_COLOR,
+            font=("Helvetica", 12),
+        )
+
+    def _draw_file_node(self, node):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        outline = self.resolve_color(node.get("color"), DEFAULT_NODE_OUTLINE)
+        self._create_round_rect(
+            x, y, w, h,
+            fill=DEFAULT_NODE_FILL, outline=outline, width=2,
+        )
+        filename = os.path.basename(node.get("file", "")) or node.get("file", "")
+        self.widget.create_text(
+            x + 10, y + 10,
+            text=f"\U0001F4C4 {filename}",
+            anchor="nw",
+            width=max(w - 20, 1),
+            fill=DEFAULT_TEXT_COLOR,
+            font=("Helvetica", 12, "bold"),
+        )
+        subpath = node.get("subpath")
+        if subpath:
+            self.widget.create_text(
+                x + 10, y + 32,
+                text=subpath, anchor="nw",
+                width=max(w - 20, 1),
+                fill="#808080",
+                font=("Helvetica", 10, "italic"),
+            )
+
+    def _draw_link_node(self, node):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        outline = self.resolve_color(node.get("color"), DEFAULT_NODE_OUTLINE)
+        self._create_round_rect(
+            x, y, w, h,
+            fill=DEFAULT_NODE_FILL, outline=outline, width=2,
+        )
+        url = node.get("url", "")
+        self.widget.create_text(
+            x + 10, y + 10,
+            text=f"\U0001F517 {url}",
+            anchor="nw",
+            width=max(w - 20, 1),
+            fill="#2060c0",
+            font=("Helvetica", 12, "underline"),
+        )
+
+    def _draw_edge(self, edge, nodes_by_id):
+        src = nodes_by_id.get(edge.get("fromNode"))
+        dst = nodes_by_id.get(edge.get("toNode"))
+        if src is None or dst is None:
+            return
+
+        from_side = edge.get("fromSide") or self._closest_side(src, dst)
+        to_side = edge.get("toSide") or self._closest_side(dst, src)
+        x1, y1 = self._anchor_point(src, from_side)
+        x2, y2 = self._anchor_point(dst, to_side)
+
+        from_end = edge.get("fromEnd", "none")
+        to_end = edge.get("toEnd", "arrow")
+        arrow = self._arrow_option(from_end, to_end)
+
+        color = self.resolve_color(edge.get("color"), DEFAULT_EDGE_COLOR)
+
+        self.widget.create_line(
+            x1, y1, x2, y2,
+            fill=color, width=2,
+            arrow=arrow, arrowshape=(12, 14, 5),
+        )
+
+        label = edge.get("label")
+        if label:
+            mx, my = (x1 + x2) / 2, (y1 + y2) / 2
+            self.widget.create_text(
+                mx, my, text=label, fill=color,
+                font=("Helvetica", 10),
+            )
+
+    @staticmethod
+    def _arrow_option(from_end, to_end):
+        has_from = from_end == "arrow"
+        has_to = to_end == "arrow"
+        if has_from and has_to:
+            return "both"
+        if has_to:
+            return "last"
+        if has_from:
+            return "first"
+        return "none"
+
+    @staticmethod
+    def _anchor_point(node, side):
+        x, y, w, h = node["x"], node["y"], node["width"], node["height"]
+        if side == "top":
+            return x + w / 2, y
+        if side == "bottom":
+            return x + w / 2, y + h
+        if side == "left":
+            return x, y + h / 2
+        if side == "right":
+            return x + w, y + h / 2
+        return x + w / 2, y + h / 2
+
+    @staticmethod
+    def _closest_side(src, dst):
+        sx = src["x"] + src["width"] / 2
+        sy = src["y"] + src["height"] / 2
+        dx = dst["x"] + dst["width"] / 2
+        dy = dst["y"] + dst["height"] / 2
+        vx, vy = dx - sx, dy - sy
+        if abs(vx) >= abs(vy):
+            return "right" if vx >= 0 else "left"
+        return "bottom" if vy >= 0 else "top"

--- a/mytk/tests/testJSONCanvas.py
+++ b/mytk/tests/testJSONCanvas.py
@@ -1,0 +1,198 @@
+import unittest
+
+import envtest
+
+from mytk import JSONCanvas
+from mytk.jsoncanvas import PRESET_COLORS
+
+
+SAMPLE_TEXT_NODE = {
+    "id": "t1",
+    "type": "text",
+    "x": 0, "y": 0, "width": 200, "height": 60,
+    "text": "Hello world",
+}
+
+SAMPLE_FILE_NODE = {
+    "id": "f1",
+    "type": "file",
+    "x": 0, "y": 100, "width": 200, "height": 60,
+    "file": "notes/example.md",
+    "subpath": "#heading",
+}
+
+SAMPLE_LINK_NODE = {
+    "id": "l1",
+    "type": "link",
+    "x": 0, "y": 200, "width": 200, "height": 60,
+    "url": "https://example.com",
+}
+
+SAMPLE_GROUP_NODE = {
+    "id": "g1",
+    "type": "group",
+    "x": -20, "y": -20, "width": 400, "height": 320,
+    "label": "My group",
+}
+
+
+class TestJSONCanvasBasics(envtest.MyTkTestCase):
+    def setUp(self):
+        super().setUp()
+        self.canvas = JSONCanvas(width=400, height=400)
+        self.canvas.grid_into(self.app.window, row=0, column=0)
+
+    def test_init(self):
+        self.assertIsNotNone(self.canvas)
+        self.assertIsNone(self.canvas._data)
+
+    def test_load_empty_document(self):
+        self.canvas.load({})
+        self.assertEqual(len(self.canvas.widget.find_all()), 0)
+
+    def test_load_empty_nodes_and_edges(self):
+        self.canvas.load({"nodes": [], "edges": []})
+        self.assertEqual(len(self.canvas.widget.find_all()), 0)
+
+    def test_load_text_node_creates_items(self):
+        self.canvas.load({"nodes": [SAMPLE_TEXT_NODE]})
+        items = self.canvas.widget.find_all()
+        self.assertGreaterEqual(len(items), 2)
+
+    def test_load_all_node_types(self):
+        self.canvas.load({
+            "nodes": [
+                SAMPLE_GROUP_NODE,
+                SAMPLE_TEXT_NODE,
+                SAMPLE_FILE_NODE,
+                SAMPLE_LINK_NODE,
+            ],
+        })
+        self.assertGreaterEqual(len(self.canvas.widget.find_all()), 4)
+
+    def test_reload_replaces_previous_items(self):
+        self.canvas.load({"nodes": [SAMPLE_TEXT_NODE]})
+        first_count = len(self.canvas.widget.find_all())
+        self.canvas.load({"nodes": [SAMPLE_TEXT_NODE]})
+        second_count = len(self.canvas.widget.find_all())
+        self.assertEqual(first_count, second_count)
+
+    def test_scrollregion_is_set(self):
+        self.canvas.load({"nodes": [SAMPLE_TEXT_NODE]})
+        region = self.canvas.widget.cget("scrollregion").split()
+        self.assertEqual(len(region), 4)
+        x1, y1, x2, y2 = (float(v) for v in region)
+        self.assertLess(x1, 0)
+        self.assertGreater(x2, SAMPLE_TEXT_NODE["width"])
+
+
+class TestJSONCanvasEdges(envtest.MyTkTestCase):
+    def setUp(self):
+        super().setUp()
+        self.canvas = JSONCanvas(width=400, height=400)
+        self.canvas.grid_into(self.app.window, row=0, column=0)
+
+    def _two_node_doc(self, edge_overrides=None):
+        edge = {"id": "e1", "fromNode": "a", "toNode": "b"}
+        if edge_overrides:
+            edge.update(edge_overrides)
+        return {
+            "nodes": [
+                {"id": "a", "type": "text", "x": 0, "y": 0,
+                 "width": 100, "height": 60, "text": "A"},
+                {"id": "b", "type": "text", "x": 300, "y": 0,
+                 "width": 100, "height": 60, "text": "B"},
+            ],
+            "edges": [edge],
+        }
+
+    def test_edge_renders_between_nodes(self):
+        self.canvas.load(self._two_node_doc())
+        lines = self.canvas.widget.find_withtag("all")
+        kinds = {self.canvas.widget.type(i) for i in lines}
+        self.assertIn("line", kinds)
+
+    def test_edge_with_label_adds_text(self):
+        self.canvas.load(self._two_node_doc({"label": "hello"}))
+        texts = [i for i in self.canvas.widget.find_all()
+                 if self.canvas.widget.type(i) == "text"]
+        text_values = [self.canvas.widget.itemcget(i, "text") for i in texts]
+        self.assertTrue(any("hello" in t for t in text_values))
+
+    def test_closest_side_defaults(self):
+        self.assertEqual(
+            JSONCanvas._closest_side(
+                {"x": 0, "y": 0, "width": 10, "height": 10},
+                {"x": 100, "y": 0, "width": 10, "height": 10},
+            ),
+            "right",
+        )
+        self.assertEqual(
+            JSONCanvas._closest_side(
+                {"x": 0, "y": 0, "width": 10, "height": 10},
+                {"x": 0, "y": 100, "width": 10, "height": 10},
+            ),
+            "bottom",
+        )
+
+    def test_anchor_points(self):
+        node = {"x": 10, "y": 20, "width": 100, "height": 40}
+        self.assertEqual(JSONCanvas._anchor_point(node, "top"), (60, 20))
+        self.assertEqual(JSONCanvas._anchor_point(node, "bottom"), (60, 60))
+        self.assertEqual(JSONCanvas._anchor_point(node, "left"), (10, 40))
+        self.assertEqual(JSONCanvas._anchor_point(node, "right"), (110, 40))
+
+    def test_arrow_option_mapping(self):
+        self.assertEqual(JSONCanvas._arrow_option("none", "arrow"), "last")
+        self.assertEqual(JSONCanvas._arrow_option("arrow", "none"), "first")
+        self.assertEqual(JSONCanvas._arrow_option("arrow", "arrow"), "both")
+        self.assertEqual(JSONCanvas._arrow_option("none", "none"), "none")
+
+
+class TestJSONCanvasColors(envtest.MyTkTestCase):
+    def setUp(self):
+        super().setUp()
+        self.canvas = JSONCanvas(width=400, height=400)
+        self.canvas.grid_into(self.app.window, row=0, column=0)
+
+    def test_preset_color_mapping(self):
+        for key, hex_value in PRESET_COLORS.items():
+            self.assertEqual(JSONCanvas.resolve_color(key, "#000"), hex_value)
+
+    def test_hex_color_passthrough(self):
+        self.assertEqual(JSONCanvas.resolve_color("#abcdef", "#000"), "#abcdef")
+
+    def test_none_returns_default(self):
+        self.assertEqual(JSONCanvas.resolve_color(None, "#123456"), "#123456")
+
+    def test_preset_color_renders(self):
+        node = dict(SAMPLE_TEXT_NODE, color="1")
+        self.canvas.load({"nodes": [node]})
+        shapes = [i for i in self.canvas.widget.find_all()
+                  if self.canvas.widget.type(i) in ("polygon", "rectangle")]
+        self.assertTrue(shapes)
+        outlines = {self.canvas.widget.itemcget(s, "outline") for s in shapes}
+        self.assertIn(PRESET_COLORS["1"], outlines)
+
+
+class TestJSONCanvasMainloop(envtest.MyTkTestCase):
+    def setUp(self):
+        super().setUp()
+        self.canvas = JSONCanvas(width=400, height=400)
+        self.canvas.grid_into(self.app.window, row=0, column=0)
+
+    def _load_sample(self):
+        self.canvas.load({
+            "nodes": [SAMPLE_GROUP_NODE, SAMPLE_TEXT_NODE, SAMPLE_FILE_NODE,
+                      SAMPLE_LINK_NODE],
+            "edges": [{"id": "e1", "fromNode": "t1", "toNode": "l1",
+                       "fromSide": "bottom", "toSide": "top", "label": "link"}],
+        })
+
+    def test_load_in_mainloop(self):
+        self.start_timed_mainloop(function=self._load_sample, timeout=300)
+        self.app.mainloop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `JSONCanvas(CanvasView)` class in `mytk/jsoncanvas.py` that renders [JSON Canvas 1.0](https://jsoncanvas.org/spec/1.0/) documents via `load(dict)` / `load_from_file(path)`
- Supports all four node types (text / file / link / group) with rounded corners, edges anchored to node sides with arrowhead control (`fromEnd` / `toEnd`), preset color mapping (1–6 → hex), and automatic `scrollregion` from node bbox
- Exported from `mytk`; 17 new unit tests in `mytk/tests/testJSONCanvas.py`; demo in `mytk/example_apps/jsoncanvas_app.py`

## Scope / limitations (v1, intentional)
- Viewer only — no editing, pan/zoom, or write-back
- Text nodes render as plain text (no markdown), file nodes show basename (no embedded content), group `background` image not drawn
- Edges are straight lines — curved-edge rendering was explored but Tk 8.6's canvas rasterization produced visibly poor results, so straight lines stayed

## Test plan
- [x] `cd mytk/tests && python3 -m unittest testJSONCanvas.py` — 17/17 pass
- [x] `cd mytk/tests && python3 -m unittest discover -p "test*.py"` — 409/409 pass (4 skipped, pandas-optional)
- [x] `python3 mytk/example_apps/jsoncanvas_app.py` — loads built-in sample; "Load…" button opens an arbitrary `.canvas`/`.json` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)