### PR TITLE
Fix two flaky tests in testEntries and testModulesManager

### DIFF
--- a/mytk/tests/testEntries.py
+++ b/mytk/tests/testEntries.py
@@ -371,7 +371,12 @@ class TestCellEntry(envtest.MyTkTestCase):
         def edit_and_press_return():
             ce.widget.focus_set()
             ce.value_variable.set("Bob")
-            ce.widget.event_generate("<Return>")
+            # update() realizes the widget and applies the focus change, then
+            # when="now" dispatches the key event synchronously to the widget's
+            # binding. Without both, the commit handler may not have run by the
+            # time the record is read below (order/timing-flaky).
+            ce.widget.update()
+            ce.widget.event_generate("<Return>", when="now")
 
         self.start_timed_mainloop(function=edit_and_press_return, timeout=400)
         self.app.mainloop()
@@ -394,7 +399,11 @@ class TestCellEntry(envtest.MyTkTestCase):
         def edit_and_press_return():
             ce.widget.focus_set()
             ce.value_variable.set("notanumber")
-            ce.widget.event_generate("<Return>")
+            # update() realizes the widget and applies the focus change, then
+            # when="now" dispatches synchronously so the commit handler runs
+            # before we read the record (default "tail" only queues the event).
+            ce.widget.update()
+            ce.widget.event_generate("<Return>", when="now")
             result.append(
                 self.tableview.data_source.record(self.item_id)["score"]
             )

--- a/mytk/tests/testModulesManager.py
+++ b/mytk/tests/testModulesManager.py
@@ -1,18 +1,24 @@
 import unittest
+import uuid
 
 import envtest
 
 from mytk import *
 
+# A module name guaranteed not to exist locally or on PyPI, used to exercise the
+# "missing module" code paths. "alouette" used to serve this role but a real
+# PyPI package by that name now exists, so the negative assertions broke.
+ABSENT_MODULE = f"mytk_absent_{uuid.uuid4().hex}"
+
 
 class TestModulesManager(envtest.MyTkTestCase):
     def test_is_installed(self):
         self.assertTrue(ModulesManager.is_installed("io"))
-        self.assertFalse(ModulesManager.is_installed("alouette"))
+        self.assertFalse(ModulesManager.is_installed(ABSENT_MODULE))
 
     def test_is_not_installed(self):
         self.assertFalse(ModulesManager.is_not_installed("io"))
-        self.assertTrue(ModulesManager.is_not_installed("alouette"))
+        self.assertTrue(ModulesManager.is_not_installed(ABSENT_MODULE))
 
     def test_is_imported(self):
         self.assertTrue(ModulesManager.is_imported("io"))
@@ -22,7 +28,7 @@ class TestModulesManager(envtest.MyTkTestCase):
 
     def test_install_error_module(self):
         with self.assertRaises(RuntimeError):
-            ModulesManager.install_module("alouette")
+            ModulesManager.install_module(ABSENT_MODULE)
 
     def test_install_import(self):
         ModulesManager.install_and_import_modules_if_absent(
@@ -32,13 +38,13 @@ class TestModulesManager(envtest.MyTkTestCase):
     def test_install_import_error(self):
         with self.assertRaises(RuntimeError):
             ModulesManager.install_and_import_modules_if_absent(
-                {"alouette": "alouette"}, ask_for_confirmation=False
+                {ABSENT_MODULE: ABSENT_MODULE}, ask_for_confirmation=False
             )
 
     def test_validate_environment_error(self):
         with self.assertRaises(RuntimeError):
             ModulesManager.validate_environment(
-                {"alouette": "alouette"}, ask_for_confirmation=False
+                {ABSENT_MODULE: ABSENT_MODULE}, ask_for_confirmation=False
             )
 
     def test_validate_environment_no_error(self):


### PR DESCRIPTION
## Summary

Fixes the 6 failing tests in the suite (two distinct root causes), restoring a fully green run: **405 passed, 4 skipped, 0 failed**.

### 1. `testModulesManager` (5 tests)
These hardcoded the name `"alouette"` as a module that "could never be installed," then asserted it was absent / that installing it raised `RuntimeError`. A real PyPI package named [`alouette`](https://pypi.org/project/alouette/) now exists and is present in the venv, so every negative assertion flipped.

**Fix:** generate a per-run name guaranteed absent both locally and on PyPI — `ABSENT_MODULE = f"mytk_absent_{uuid.uuid4().hex}"` — and use it wherever `"alouette"` appeared. Faithful to the original intent (the `*_error` tests still shell out to `pip install` and expect failure), just no longer hostage to what's published on PyPI.

### 2. `TestCellEntry` `<Return>` tests (2 tests)
`test_return_key_updates_record` and `test_return_key_invalid_value_sets_none` were order/timing-flaky: the simulated `event_generate("<Return>")` didn't reach the widget's commit binding before the record was read, so which one failed depended on run order.

**Fix:** `ce.widget.update()` (realize the widget + apply the focus change) then `event_generate("<Return>", when="now")` (synchronous dispatch). Determined empirically — neither change alone was sufficient.

## Test plan
- `TestCellEntry`: 8/8 passed across 5 repeated runs (previously failed 1–2 every run).
- `testModulesManager`: 9/9.
- Full suite: **405 passed, 4 skipped, 0 failed** (~69s), no regressions.

No library code changed — these were test-harness artifacts, not `mytk/` bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)