### PR TITLE
Make grid resizing clearer: fill= shortcut, honored sizes, describe fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to myTk are documented here.
 
+## [Unreleased]
+### Added
+- `grid_into(fill=...)` resize shortcut: sets the child's `sticky` and the parent row/column `weight` together so a widget actually grows with the window. Accepts `True`/`"both"`, `"x"`/`"width"`, `"y"`/`"height"`. Existing explicit (nonzero) weights are preserved; cannot be combined with an explicit `sticky`.
+
+### Changed
+- `View` and `Box` now disable grid propagation (`grid_propagate(False)`) when **both** `width` and `height` are given, so the requested pixel size is honored instead of being silently overridden by the size of their children. A single dimension (e.g. `Box(width=100)`) or no dimension still sizes to content as before. `View`'s `width`/`height` are now optional — `View()` produces a content-sized frame.
+
+### Fixed
+- `grid_into(describe=True)` diagnostics: width/height were swapped (n/s reported as width, e/w as height) and the "expands to fill extra space" booleans were inverted (printed `True` when weight was 0). Output now reports `(width, height)` correctly.
+
 ## [0.10.11] - 2026-02-26
 ### Fixed
 - `TabularData._normalize_record()` no longer mutates `required_fields` on every insert

--- a/mytk/base.py
+++ b/mytk/base.py
@@ -86,12 +86,36 @@ class _BaseWidget:
         for i, element in enumerate(elements):
             element.grid_into(self, row=start_row + i, column=column, **kwargs)
 
-    def grid_into(self, parent=None, widget=None, describe=False, **kwargs):
+    # Maps the high-level `fill` shortcut to (sticky, grow_column, grow_row).
+    # Making a widget resize needs two things that must agree: `sticky` on the
+    # child (fill the cell) and `weight` on the parent's row/column (grow the
+    # cell). `fill` sets both at once. e/w are horizontal (width → column);
+    # n/s are vertical (height → row).
+    _FILL_MAP = {
+        True: ("nsew", True, True),
+        "both": ("nsew", True, True),
+        "x": ("ew", True, False),
+        "width": ("ew", True, False),
+        "y": ("ns", False, True),
+        "height": ("ns", False, True),
+    }
+
+    def grid_into(
+        self, parent=None, widget=None, fill=None, describe=False, **kwargs
+    ):
         """Places the widget into a grid layout.
 
         Args:
             parent (Base): Parent widget wrapper.
             widget (tk.Widget): Optional target widget.
+            fill: High-level resize shortcut. Sets both the child's `sticky`
+                and the parent row/column `weight` so the widget actually grows
+                with the window. One of: ``True``/``"both"`` (fill and grow in
+                both directions), ``"x"``/``"width"`` (horizontal only),
+                ``"y"``/``"height"`` (vertical only), or ``None`` (default, no
+                automatic resizing). Cannot be combined with an explicit
+                ``sticky``. The parent weight is only set when it is currently
+                0, so explicit proportional weights are preserved.
             describe (bool): If True, prints diagnostics about layout and geometry.
             **kwargs: Grid options (row, column, sticky, etc.)
         """
@@ -101,6 +125,23 @@ class _BaseWidget:
             "column": kwargs.get("column", 0),
         }
         self._grid_kwargs = kwargs
+
+        grow_column = grow_row = False
+        if fill is not None:
+            if "sticky" in kwargs:
+                raise ValueError(
+                    "Use either fill=... or sticky=..., not both: fill sets "
+                    "sticky and the parent row/column weight together."
+                )
+            key = fill.lower() if isinstance(fill, str) else fill
+            try:
+                fill_sticky, grow_column, grow_row = Base._FILL_MAP[key]
+            except (KeyError, TypeError):
+                raise ValueError(
+                    f"Invalid fill={fill!r}. Use True/'both', 'x'/'width', "
+                    f"or 'y'/'height'."
+                )
+            kwargs["sticky"] = fill_sticky
 
         if widget is not None:
             self.create_widget(master=widget)
@@ -125,20 +166,25 @@ class _BaseWidget:
         if self.widget is not None:
             self.widget.grid(kwargs)
 
+        # `widget` is the parent/master container here. Give its row/column the
+        # weight implied by `fill` so the cell (and thus the child) grows with
+        # available space. Only set it when unset, to keep explicit weights.
+        if grow_column and widget.grid_columnconfigure(column)["weight"] == 0:
+            widget.grid_columnconfigure(column, weight=1)
+        if grow_row and widget.grid_rowconfigure(row)["weight"] == 0:
+            widget.grid_rowconfigure(row, weight=1)
+
         if describe or Base.debug:
             try:
                 print(
                     f"\nPlacing widget {_class_nice_(self)} into {_class_nice_(parent)}.grid({row},{column})"
                 )
-                stretch_width_to_fit = False
-                if "n" in sticky and "s" in sticky:
-                    stretch_width_to_fit = True
-
-                stretch_height_to_fit = False
-                if "e" in sticky and "w" in sticky:
-                    stretch_height_to_fit = True
+                # sticky e+w (horizontal) stretches width; n+s (vertical)
+                # stretches height. The widget only fills its cell on these axes.
+                stretch_width_to_fit = "e" in sticky and "w" in sticky
+                stretch_height_to_fit = "n" in sticky and "s" in sticky
                 print(
-                    f"  Widget size expands to fit grid cell:  (w, h):{stretch_width_to_fit, stretch_height_to_fit}"
+                    f"  Widget stretches to fill its cell (width, height): {stretch_width_to_fit, stretch_height_to_fit}"
                 )
 
                 row_weight = parent.widget.grid_rowconfigure(row)["weight"]
@@ -146,8 +192,10 @@ class _BaseWidget:
                     "weight"
                 ]
 
+                # The cell only grows with the window when its weight is > 0:
+                # column weight governs width, row weight governs height.
                 print(
-                    f"  Grid cell expands to fill extra space: (h, w):{row_weight==0, column_weight==0}, {row_weight, column_weight}"
+                    f"  Grid cell grows with extra space (width, height): {column_weight != 0, row_weight != 0} (column weight={column_weight}, row weight={row_weight})"
                 )
                 print(
                     f"  Parent propagates resize to parents: {parent.widget.propagate() != 0}"

--- a/mytk/tests/testGridFill.py
+++ b/mytk/tests/testGridFill.py
@@ -1,0 +1,111 @@
+import unittest
+
+import envtest
+
+from mytk import *
+
+
+class TestGridFill(envtest.MyTkTestCase):
+    """grid_into(fill=...) sets both the child sticky and the parent weight."""
+
+    def setUp(self):
+        super().setUp()
+        self.container = View(width=200, height=200)
+        self.container.grid_into(self.app.window, row=0, column=0)
+
+    def make_child(self):
+        return View(width=50, height=50)
+
+    def col_weight(self, index=0):
+        return self.container.widget.grid_columnconfigure(index)["weight"]
+
+    def row_weight(self, index=0):
+        return self.container.widget.grid_rowconfigure(index)["weight"]
+
+    def sticky_of(self, child):
+        return set(child.widget.grid_info()["sticky"])
+
+    def test_fill_both_sets_sticky_and_both_weights(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="both")
+        self.assertEqual(self.sticky_of(child), set("nsew"))
+        self.assertEqual(self.col_weight(0), 1)
+        self.assertEqual(self.row_weight(0), 1)
+
+    def test_fill_true_is_both(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill=True)
+        self.assertEqual(self.sticky_of(child), set("nsew"))
+        self.assertEqual(self.col_weight(0), 1)
+        self.assertEqual(self.row_weight(0), 1)
+
+    def test_fill_width_horizontal_only(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="width")
+        self.assertEqual(self.sticky_of(child), set("ew"))
+        self.assertEqual(self.col_weight(0), 1)
+        self.assertEqual(self.row_weight(0), 0)
+
+    def test_fill_x_alias(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="x")
+        self.assertEqual(self.sticky_of(child), set("ew"))
+        self.assertEqual(self.col_weight(0), 1)
+        self.assertEqual(self.row_weight(0), 0)
+
+    def test_fill_height_vertical_only(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="height")
+        self.assertEqual(self.sticky_of(child), set("ns"))
+        self.assertEqual(self.col_weight(0), 0)
+        self.assertEqual(self.row_weight(0), 1)
+
+    def test_fill_y_alias(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="y")
+        self.assertEqual(self.sticky_of(child), set("ns"))
+        self.assertEqual(self.col_weight(0), 0)
+        self.assertEqual(self.row_weight(0), 1)
+
+    def test_fill_is_case_insensitive(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="BOTH")
+        self.assertEqual(self.col_weight(0), 1)
+        self.assertEqual(self.row_weight(0), 1)
+
+    def test_no_fill_leaves_weights_zero(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, sticky="nsew")
+        self.assertEqual(self.col_weight(0), 0)
+        self.assertEqual(self.row_weight(0), 0)
+
+    def test_fill_preserves_explicit_weight(self):
+        self.container.widget.grid_columnconfigure(0, weight=3)
+        child = self.make_child()
+        child.grid_into(self.container, row=0, column=0, fill="both")
+        self.assertEqual(self.col_weight(0), 3)  # preserved, not clobbered
+        self.assertEqual(self.row_weight(0), 1)  # newly set
+
+    def test_fill_targets_the_right_cell(self):
+        child = self.make_child()
+        child.grid_into(self.container, row=2, column=3, fill="both")
+        self.assertEqual(self.col_weight(3), 1)
+        self.assertEqual(self.row_weight(2), 1)
+        self.assertEqual(self.col_weight(0), 0)
+        self.assertEqual(self.row_weight(0), 0)
+
+    def test_fill_with_sticky_raises(self):
+        child = self.make_child()
+        with self.assertRaises(ValueError):
+            child.grid_into(
+                self.container, row=0, column=0, fill="both", sticky="ew"
+            )
+
+    def test_invalid_fill_raises(self):
+        child = self.make_child()
+        with self.assertRaises(ValueError):
+            child.grid_into(self.container, row=0, column=0, fill="diagonal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mytk/tests/testView.py
+++ b/mytk/tests/testView.py
@@ -101,5 +101,40 @@ class TestViewDisablePropagation(envtest.MyTkTestCase):
         self.assertTrue(label.is_disabled)
 
 
+class TestRequestedSizeHonored(envtest.MyTkTestCase):
+    """A container freezes its size only when both width and height are given."""
+
+    def propagation(self, container):
+        # grid_propagate() returns the current setting: True = sizes to content,
+        # False = holds the requested width/height.
+        return bool(container.widget.grid_propagate())
+
+    def test_view_with_both_dimensions_disables_propagation(self):
+        view = View(width=300, height=200)
+        view.grid_into(self.app.window, row=0, column=0)
+        self.assertFalse(self.propagation(view))
+
+    def test_view_without_dimensions_keeps_propagation(self):
+        view = View()
+        view.grid_into(self.app.window, row=0, column=0)
+        self.assertTrue(self.propagation(view))
+
+    def test_box_label_only_keeps_propagation(self):
+        box = Box(label="Group")
+        box.grid_into(self.app.window, row=0, column=0)
+        self.assertTrue(self.propagation(box))
+
+    def test_box_width_only_keeps_propagation(self):
+        # Freezing on a single dimension would collapse the other, so don't.
+        box = Box(label="Group", width=120)
+        box.grid_into(self.app.window, row=0, column=0)
+        self.assertTrue(self.propagation(box))
+
+    def test_box_with_both_dimensions_disables_propagation(self):
+        box = Box(label="Group", width=200, height=100)
+        box.grid_into(self.app.window, row=0, column=0)
+        self.assertFalse(self.propagation(box))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mytk/views.py
+++ b/mytk/views.py
@@ -10,6 +10,24 @@ from tkinter import ttk
 from .base import Base, _BaseWidget
 
 
+def _honor_requested_size(widget, widget_args):
+    """Stop a container from resizing to fit its children when an explicit
+    width *and* height were requested, so the requested pixel size is honored.
+
+    Tk frames propagate their children's size requests upward by default
+    (grid_propagate True), which silently overrides the width/height passed to
+    the constructor as soon as a child is added. Disabling propagation makes the
+    constructor arguments mean what they say. Only applied when both dimensions
+    are given: grid_propagate is all-or-nothing, so a single dimension cannot be
+    frozen on its own without collapsing the other.
+    """
+    if (
+        widget_args.get("width") is not None
+        and widget_args.get("height") is not None
+    ):
+        widget.grid_propagate(False)
+
+
 class View(Base):
     """A generic frame container used to group widgets together.
 
@@ -22,12 +40,17 @@ class View(Base):
         **kwargs: Additional keyword arguments passed to Base.
     """
 
-    def __init__(self, width, height, *args, **kwargs):
-        """Initializes the View with a fixed width and height.
+    def __init__(self, width=None, height=None, *args, **kwargs):
+        """Initializes the View, optionally with a requested width and height.
+
+        When both width and height are given, the frame keeps that pixel size
+        instead of shrinking to fit its children (grid propagation is disabled).
+        Omit them (or pass only one) to let the frame size itself to its
+        content, as Tk does by default.
 
         Args:
-            width (int): Width of the frame in pixels.
-            height (int): Height of the frame in pixels.
+            width (int, optional): Requested width of the frame in pixels.
+            height (int, optional): Requested height of the frame in pixels.
             *args: Additional positional arguments passed to Base.
             **kwargs: Additional keyword arguments passed to Base.
         """
@@ -45,6 +68,7 @@ class View(Base):
         self.widget = ttk.Frame(
             master, **self._widget_args, **self.debug_kwargs
         )
+        _honor_requested_size(self.widget, self._widget_args)
 
     @property
     def is_disabled(self):
@@ -95,6 +119,7 @@ class Box(Base):
             **self._widget_args,
             **self.debug_kwargs,
         )
+        _honor_requested_size(self.widget, self._widget_args)
 
     @property
     def is_disabled(self):


### PR DESCRIPTION
## Summary

Three related changes addressing the long-standing confusion around `grid` resizing — where setting `sticky="nsew"` alone often *didn't* make a widget stretch or follow the window. The root cause is that resize intent is split across three knobs that must agree: **`sticky`** (fill the cell), **`weight`** (grow the cell), and **`grid_propagate`** (whether a container sizes to its content or holds its own size). This PR makes each one easier to get right.

### Added — `grid_into(fill=...)`
Unifies the two-part `sticky` + `weight` requirement so the child declares its resize intent in one place, and `grid_into` sets both the child's `sticky` *and* the parent row/column `weight`.

```python
view.grid_into(window, row=0, column=0, fill="both")   # sticky=nsew + row/col weight=1
panel.grid_into(window, row=1, column=0, fill="width")  # sticky=ew + column weight=1
```

| `fill` | child `sticky` | parent weight |
|---|---|---|
| `True` / `"both"` | `nsew` | column + row |
| `"x"` / `"width"` | `ew` | column |
| `"y"` / `"height"` | `ns` | row |
| `None` (default) | — | — (unchanged) |

- **Opt-in**: `sticky=` behaves exactly as before; existing layouts are untouched.
- **Preserves explicit weights**: only sets weight when the row/column is currently `0`, so proportional splits aren't clobbered.
- **Fails loudly**: `fill` + `sticky` together, or an unknown `fill` value, raise `ValueError`.

### Changed — `View`/`Box` honor a requested size
`View` and `Box` now call `grid_propagate(False)` when **both** `width` and `height` are given, so the requested pixel size is honored instead of being silently overridden by child content. A single dimension (e.g. `Box(width=100)`) or none still sizes to content — freezing one axis alone would collapse the other. `View`'s `width`/`height` are now **optional**, so `View()` yields a content-sized frame.

> ⚠️ **Behavior change**: an app that passed `width`+`height` to a `View`/`Box` and relied on it collapsing to content will now see it hold its stated size. Such frames are usually stretched by weight/sticky (where sticky wins anyway) or the stated size was the intent; the test suite and example call sites are consistent with that, but a visual check of the example apps before release is worthwhile.

### Fixed — `grid_into(describe=True)` diagnostics
The debug readout had width/height **swapped** (n/s reported as width, e/w as height) and the "expands to fill extra space" booleans **inverted** (printed `True` when weight was `0`). It now reports `(width, height)` correctly — relevant because this is the tool you'd reach for to debug a resize problem.

## Test plan
- New `mytk/tests/testGridFill.py` — 12 tests for `fill=` (each direction, aliases, weight preservation, target cell, error cases).
- New `TestRequestedSizeHonored` in `mytk/tests/testView.py` — 5 tests for the propagation rule (both dims off, single dim / none on).
- Full suite: **422 passed, 4 skipped, 0 failed**, including the pre-existing `TestViewDisablePropagation` tests (sized Views now run with propagation off) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)