### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to myTk are documented here.
 
-## [Unreleased]
+## [1.1.0] - 2026-05-23
 ### Added
 - `grid_into(fill=...)` resize shortcut: sets the child's `sticky` and the parent row/column `weight` together so a widget actually grows with the window. Accepts `True`/`"both"`, `"x"`/`"width"`, `"y"`/`"height"`. Existing explicit (nonzero) weights are preserved; cannot be combined with an explicit `sticky`.
 


### PR DESCRIPTION
Finalizes the changelog for **1.1.0** by converting `[Unreleased]` → `[1.1.0] - 2026-05-23`.

The version is tag-driven (`setuptools-scm`), so once this merges I'll create and push the **`v1.1.0`** tag on the merge commit to actually bump the version. Latest tag was `v1.0.3`; chose a minor bump for the new `grid_into(fill=...)` feature.

Contents of 1.1.0 (merged in #60):
- **Added** — `grid_into(fill=...)` resize shortcut (sets child `sticky` + parent row/column `weight` together).
- **Changed** — `View`/`Box` honor a full `width`×`height` via `grid_propagate(False)`; `View` dimensions now optional.
- **Fixed** — `grid_into(describe=True)` diagnostics (swapped width/height, inverted "expands" booleans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)