### PR TITLE
Add release automation (PyPI + GitHub Release on tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Build, publish to PyPI, and create a GitHub Release whenever a version tag
+# (vX.Y.Z) is pushed. The version itself comes from the tag via setuptools-scm.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history + tags so setuptools-scm can derive the version.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Validate metadata
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  pypi-publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Configure a matching Trusted Publisher on PyPI (see README/PR notes).
+    environment: pypi
+    permissions:
+      # OIDC token for PyPI Trusted Publishing — no API token stored in GitHub.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to create the release and upload the built artifacts to it.
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,17 +39,16 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    # Configure a matching Trusted Publisher on PyPI (see README/PR notes).
-    environment: pypi
-    permissions:
-      # OIDC token for PyPI Trusted Publishing — no API token stored in GitHub.
-      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # PyPI API token stored as the PYPI_API_TOKEN repo secret
+          # (Settings > Secrets and variables > Actions).
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: GitHub Release


### PR DESCRIPTION
Adds `.github/workflows/release.yml` so that pushing a `vX.Y.Z` tag automatically:

1. **Builds** sdist + wheel (checks out full history so `setuptools-scm` derives the version from the tag),
2. **Validates** the artifacts with `twine check`,
3. **Publishes to PyPI** using the `PYPI_API_TOKEN` repo secret,
4. **Creates a GitHub Release** with auto-generated notes and the built artifacts attached.

This makes "tag = release + PyPI" actually true — the behavior that was assumed but didn't exist (there was no CI at all; v1.0.3 never even got a GitHub Release).

> Note: this workflow is **not** retroactive — v1.1.0 was released manually. The automation kicks in for the **next** tag after this merges.

## Setup status
- ✅ `PYPI_API_TOKEN` repo secret is set (Settings → Secrets and variables → Actions).
- Recommended: scope that token to the `mytk` project on PyPI (not account-wide) so a leak is contained.

No `pypi` environment or PyPI trusted-publisher config is needed with the token approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
