### PR TITLE
Release 1.2.0: View3D in demo, changelog, README drag-and-drop highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to myTk are documented here.
 
+## [1.2.0] - 2026-06-13
+### Added
+- **Drag-and-drop**: any widget can accept files dropped from the OS file
+  manager via `Base.accept_dropped_files(callback)` (new `DragAndDropCapable`
+  mixin, modelled on `EventCapable`). Built on the optional `tkinterdnd2`/tkdnd
+  extension, installed on demand and matched to the running Tcl version; the
+  callback runs on the next event-loop tick (safe for dialogs/slow work), and
+  drag-and-drop degrades gracefully when the extension can't be loaded.
+- **`View3D`**: an embedded off-screen 3D mesh viewer. Loads GLB/GLTF/OBJ/PLY/STL
+  via trimesh and renders it inside a normal myTk layout — drag to orbit, scroll
+  to zoom, drop a mesh onto it to load. `View3D(...)` is a factory that picks a
+  backend (`View3DPyrender` preferred, `View3DModernGL` fallback); per-vertex
+  glTF `COLOR_0` alpha is honoured so translucent meshes render correctly. Heavy
+  dependencies are optional and installed on demand.
+- New examples: `view3d_app.py` and `dnd_app.py`; the capabilities demo
+  (`example.py`) now includes a `View3D`, and `pydatagraph_app.py` loads
+  Excel/CSV files by drag-and-drop.
+
 ## [1.1.0] - 2026-05-23
 ### Added
 - `grid_into(fill=...)` resize shortcut: sets the child's `sticky` and the parent row/column `weight` together so a widget actually grows with the window. Accepts `True`/`"both"`, `"x"`/`"width"`, `"y"`/`"height"`. Existing explicit (nonzero) weights are preserved; cannot be combined with an explicit `sticky`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ by Daniel C. Côté
 ## What is it?
 Making a UI interface should not be complicated. **myTk** is a set of UI classes that simplifies the use of Tkinter to make simple (and not so simple!) GUIs in Python.
 
+> ✨ **New:** any widget can now accept **files dropped from the OS file manager** — just call `widget.accept_dropped_files(callback)` (see [Drag and drop](#drag-and-drop)). There is also a new embedded 3D mesh viewer, [`View3D`](#classes).
+
 ## Why Tk?
 Tk comes standard with Python.  It is highly portable to all main platforms.
 

--- a/mytk/example_apps/example.py
+++ b/mytk/example_apps/example.py
@@ -86,16 +86,38 @@ if __name__ == "__main__":
     axis.plot([1, 2, 3], [4, 5, 6])
     axis.set_title("Figure", fontsize=9)
 
-    try:
-        from matplotlib.figure import Figure as MPLFigure
-        some_fig = MPLFigure(figsize=(3, 2))
-        axis = some_fig.add_subplot()
-        axis.plot([1, 2, 3], [-4, -5, -6])
-        axis.set_title("Figure (external MPLFigure)", fontsize=9)
-        figure2 = Figure(figure=some_fig)
-        figure2.grid_into(app.window, column=3, row=2, pady=2, padx=3)
-    except:
-        pass
+    # View3D: an embedded 3D mesh viewer. Only built when its (optional) 3D
+    # dependencies are already installed, so the example never triggers an
+    # install prompt; otherwise a placeholder label is shown.
+    import importlib.util
+    view3d_box = Box(label="View3D")
+    view3d_box.grid_into(app.window, column=3, row=2, pady=2, padx=3, sticky="nsew")
+    _has_3d = importlib.util.find_spec("trimesh") and (
+        importlib.util.find_spec("pyrender")
+        or importlib.util.find_spec("moderngl")
+    )
+    if _has_3d:
+        try:
+            import os
+            import tempfile
+
+            import trimesh
+
+            cube = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+            cube.visual.vertex_colors = (200, 90, 40, 255)
+            cube_path = os.path.join(tempfile.gettempdir(), "example_cube.glb")
+            cube.export(cube_path)
+            viewer3d = View3D(width=160, height=160)
+            viewer3d.grid_into(view3d_box, column=0, row=0, pady=2, padx=3)
+            viewer3d.load_file(cube_path)
+        except Exception:
+            Label("Unable to load View3D").grid_into(
+                view3d_box, column=0, row=0, pady=2, padx=3
+            )
+    else:
+        Label("Install pyrender or moderngl\nto see View3D").grid_into(
+            view3d_box, column=0, row=0, pady=2, padx=3
+        )
 
     video_box = Box(label="VideoView")
     video_box.grid_into(app.window, column=2, row=2, pady=2, padx=3, sticky="")


### PR DESCRIPTION
Prep for the **1.2.0** release.

- **`example.py`** (capabilities demo): replaced the second Figure (the external-MPLFigure one) with a **`View3D`** showing a coloured cube. It's built only when the optional 3D deps are already installed, so running the demo never triggers an install prompt — otherwise a placeholder label is shown.
- **CHANGELOG.md**: added the `[1.2.0]` entry — drag-and-drop (`DragAndDropCapable` / `accept_dropped_files`), `View3D` (two backends + factory + per-vertex `COLOR_0` alpha), and the new examples.
- **README.md**: highlighted drag-and-drop (and View3D) at the top.

After this merges, tagging `v1.2.0` triggers the Release workflow (build → PyPI → GitHub Release).

453 tests pass; example app verified to launch with the View3D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)