### PR TITLE
Fix View3D runaway resize loop (example.py hang)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to myTk are documented here.
 
+## [1.2.1] - 2026-06-13
+### Fixed
+- `View3D` hung the app when placed content-sized (no `sticky`/weight, as in the
+  capabilities demo): it blitted frames into a `ttk.Label`, which sized itself to
+  each rendered image and re-triggered `<Configure>`, growing the widget on every
+  frame in a runaway resize loop. It now renders into a `tk.Canvas`, whose size
+  is set by the layout and unaffected by what is drawn, so there is no feedback.
+
 ## [1.2.0] - 2026-06-13
 ### Added
 - **Drag-and-drop**: any widget can accept files dropped from the OS file

--- a/mytk/tests/testView3D.py
+++ b/mytk/tests/testView3D.py
@@ -78,6 +78,16 @@ class TestView3DModernGL(envtest.MyTkTestCase):
         self.assertIsNone(self.mesh_view.ctx)
         self.assertIsNone(self.mesh_view.widget)
 
+    def test_widget_is_a_canvas_not_a_label(self):
+        # Regression: a ttk.Label sized itself to each rendered frame, which grew
+        # the widget and re-triggered <Configure> in a runaway resize loop
+        # (hanging the app) when placed content-sized. A tk.Canvas keeps the size
+        # the layout gives it regardless of what is drawn, breaking the loop.
+        import tkinter as tk
+
+        self.mesh_view.grid_into(self.app.window, row=1, column=0)
+        self.assertIsInstance(self.mesh_view.widget, tk.Canvas)
+
     def test_set_geometry_stores_buffers_without_gl(self):
         import numpy as np
 

--- a/mytk/view3d.py
+++ b/mytk/view3d.py
@@ -3,7 +3,7 @@
 `View3D` is an abstract widget that loads a GLB/GLTF/OBJ/PLY file with trimesh
 and shows it lit and coloured inside an ordinary myTk layout — drag to orbit,
 scroll to zoom. Rather than embed a fragile OpenGL widget, it renders off-screen
-and blits each frame into a `ttk.Label` via Pillow, the same strategy
+and blits each frame into a `tk.Canvas` via Pillow, the same strategy
 `VideoView` uses for camera frames. It re-renders only on interaction.
 
 Two concrete implementations share that machinery:
@@ -29,7 +29,7 @@ triangles with a two-sided Lambert-ish shade — enough to inspect exported scen
 """
 
 import importlib
-import tkinter.ttk as ttk
+import tkinter as tk
 from abc import ABC, abstractmethod
 
 from .base import Base
@@ -133,9 +133,23 @@ class View3D(Base, ABC):
         return shared and self._backend_ready()
 
     def create_widget(self, master):
-        """Create the label that displays rendered frames and wire up the mouse."""
+        """Create the canvas that displays rendered frames and wire up the mouse.
+
+        A ``tk.Canvas`` (not a label) is used on purpose: a label sizes itself
+        to its image, so each rendered frame would grow the widget by its chrome
+        and re-trigger ``<Configure>`` — a runaway resize loop when the widget is
+        content-sized. A canvas keeps the size the layout gives it regardless of
+        what is drawn into it, so no feedback occurs.
+        """
         self.parent = master
-        self.widget = ttk.Label(master, background=self.background)
+        w, h = self._initial_size
+        self.widget = tk.Canvas(
+            master,
+            background=self.background,
+            width=w,
+            height=h,
+            highlightthickness=0,  # no focus border (would add to the size)
+        )
 
         self.widget.bind("<Map>", self._on_map)
         self.widget.bind("<Configure>", self._on_resize)
@@ -354,7 +368,8 @@ class View3D(Base, ABC):
         if image is None:
             return
         self._displayed_tkimage = self.PILImageTk.PhotoImage(image)
-        self.widget.configure(image=self._displayed_tkimage)
+        self.widget.delete("all")
+        self.widget.create_image(0, 0, anchor="nw", image=self._displayed_tkimage)
 
     # ------------------------------------------------------------------ #
     # Backend contract — implemented by each concrete renderer below.


### PR DESCRIPTION
## Problem
`example.py` (the capabilities demo) hangs. Isolated to **View3D** — VideoView is fine.

## Cause
View3D blitted each rendered frame into a `ttk.Label`. A label sizes itself to its image, so each frame grew the widget by its chrome (~4px), which re-triggered `<Configure>` → `_on_resize` rebuilt the framebuffer larger → rendered a bigger image → grew the label again… a runaway loop (observed 800+ renders, window growing every frame) that pegs the event loop and freezes the app.

It only bites when the widget is **content-sized** (no `sticky`/weight) — exactly how the demo places it. The old `__main__`/`view3d_app` used `sticky="nsew"` + weight (cell size fixed by the layout), so the loop never appeared and the bug shipped unnoticed in 1.2.0.

## Fix
Render into a **`tk.Canvas`** instead of a label. A canvas's size is set by the geometry manager and is unaffected by what's drawn into it, so there's no feedback in either content-sized or stretched layouts. `create_image` replaces `label.configure(image=...)`; `highlightthickness=0` drops the focus border.

Verified: the previously-hanging content-sized layout now renders twice and idles; the demo window size stays stable (1350×752) and responsive. Added a regression test that the widget is a `tk.Canvas`. 454 tests pass.

This is a hotfix for 1.2.0 → 1.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)