### PR TITLE
Fix View3D crash before geometry loads (drag-and-drop appeared broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to myTk are documented here.
 
+## [1.2.2] - 2026-06-13
+### Fixed
+- `View3D` crashed on every render when shown before any geometry was loaded
+  (e.g. `view3d_app` opened without a file): the now-default pyrender backend
+  always builds a camera pose from the bounding-box centre, which is unset until
+  a mesh loads. The camera now falls back to the origin, so an empty viewer
+  renders its background and accepts a dropped/loaded file normally.
+
+### Added
+- The capabilities demo's `View3D` now accepts dropped mesh files too (when
+  `tkinterdnd2` is already installed).
+
 ## [1.2.1] - 2026-06-13
 ### Fixed
 - `View3D` hung the app when placed content-sized (no `sticky`/weight, as in the

--- a/mytk/example_apps/example.py
+++ b/mytk/example_apps/example.py
@@ -110,6 +110,12 @@ if __name__ == "__main__":
             viewer3d = View3D(width=160, height=160)
             viewer3d.grid_into(view3d_box, column=0, row=0, pady=2, padx=3)
             viewer3d.load_file(cube_path)
+            # Drop a mesh onto the viewer to load it — only when tkinterdnd2 is
+            # already present, so the demo never triggers an install prompt.
+            if importlib.util.find_spec("tkinterdnd2"):
+                viewer3d.accept_dropped_files(
+                    lambda paths: viewer3d.load_file_or_warn(paths[0])
+                )
         except Exception:
             Label("Unable to load View3D").grid_into(
                 view3d_box, column=0, row=0, pady=2, padx=3

--- a/mytk/tests/testView3D.py
+++ b/mytk/tests/testView3D.py
@@ -78,6 +78,12 @@ class TestView3DModernGL(envtest.MyTkTestCase):
         self.assertIsNone(self.mesh_view.ctx)
         self.assertIsNone(self.mesh_view.widget)
 
+    def test_eye_with_no_geometry_does_not_crash(self):
+        # Regression: camera math used center, which is None before a mesh loads.
+        self.assertIsNone(self.mesh_view.center)
+        eye = self.mesh_view._eye()
+        self.assertEqual(len(eye), 3)
+
     def test_widget_is_a_canvas_not_a_label(self):
         # Regression: a ttk.Label sized itself to each rendered frame, which grew
         # the widget and re-triggered <Configure> in a runaway resize loop
@@ -205,6 +211,13 @@ class TestView3DPyrender(envtest.MyTkTestCase):
         self.assertIsNone(self.mesh_view._renderer)
         self.assertIsNone(self.mesh_view._scene)
         self.assertIsNone(self.mesh_view.widget)
+
+    def test_camera_pose_with_no_geometry_does_not_crash(self):
+        # Regression: an empty pyrender viewer crashed because center was None
+        # (pyrender always builds a camera pose). It must fall back to origin.
+        self.assertIsNone(self.mesh_view.center)
+        pose = self.mesh_view._camera_pose()
+        self.assertEqual(pose.shape, (4, 4))
 
 
 if __name__ == "__main__":

--- a/mytk/view3d.py
+++ b/mytk/view3d.py
@@ -271,11 +271,20 @@ class View3D(Base, ABC):
         self.distance = 2.6 * self.radius
         self._schedule_render(upload=True)
 
+    def _center_or_origin(self):
+        """Geometry centre, or the origin before any geometry is loaded.
+
+        The bounds (and centre) are unset until a mesh loads; falling back to the
+        origin lets an empty viewer render its background instead of crashing
+        (the pyrender backend always builds a camera pose from the centre).
+        """
+        return self.center if self.center is not None else self.np.zeros(3)
+
     def _eye(self):
         """Camera position on the orbit sphere for the current angles."""
         np = self.np
         ce = np.cos(self.elevation)
-        return self.center + self.distance * np.array(
+        return self._center_or_origin() + self.distance * np.array(
             [
                 ce * np.cos(self.azimuth),
                 np.sin(self.elevation),
@@ -703,7 +712,7 @@ class View3DPyrender(View3D):
         """Camera-to-world pose looking from the orbit eye at the centre."""
         np = self.np
         eye = self._eye()
-        f = self.center - eye
+        f = self._center_or_origin() - eye
         f = f / np.linalg.norm(f)            # forward (camera looks down -z)
         s = np.cross(f, (0.0, 1.0, 0.0))
         s = s / np.linalg.norm(s)            # right


### PR DESCRIPTION
## Problem
"Drag-and-drop doesn't work anymore in View3D." Investigated — drop **registration is fine** on the new `tk.Canvas` (returns True, `<<Drop>>` binds and fires; Canvas and Label register identically with tkdnd). The real regression is that the viewer **crashes on render before any geometry is loaded**.

## Cause
Since pyrender became the default backend, opening a viewer with no mesh yet (e.g. `view3d_app` launched without a file) crashes every render: pyrender's `_draw` always builds a camera pose from the bounding-box centre, which is `None` until a mesh loads. (moderngl skipped the camera math entirely when there was no geometry, so it never hit this.) The empty viewer crash-loops, so it looks broken / like drops do nothing.

## Fix
`_center_or_origin()` — `_eye` and `_camera_pose` fall back to the origin when `center` is `None`. An empty viewer now renders its background, and a dropped/loaded file displays normally. Verified: `view3d_app` with no file → 0 exceptions; empty→load works on both backends.

Also:
- The capabilities demo's `View3D` now accepts dropped mesh files (only when `tkinterdnd2` is already installed, so the demo never prompts).
- Regression tests for the no-geometry camera math on both backends.

456 tests pass. Hotfix for 1.2.1 → 1.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)