### PR TITLE
Make heavy/native features optional; keep cross-platform defaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,10 +46,9 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          # The 'test' extra brings the deps the headless suite exercises
-          # (figures, tables, clipboard, web). GPU/camera widgets (View3D,
-          # VideoView) stay optional and their tests skip when absent.
-          pip install -e ".[test]"
+          # Default deps cover the non-GPU widgets the suite exercises; the
+          # optional video/view3d/dnd features stay out and their tests skip.
+          pip install -e .
 
       - name: Set up Tk and virtual display (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,10 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          # The 'test' extra brings the deps the headless suite exercises
+          # (figures, tables, clipboard, web). GPU/camera widgets (View3D,
+          # VideoView) stay optional and their tests skip when absent.
+          pip install -e ".[test]"
 
       - name: Set up Tk and virtual display (Linux)
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to myTk are documented here.
 
+## [1.3.0] - 2026-06-13
+### Changed
+- **myTk now installs with no required third-party dependencies.** Heavy/optional
+  modules (matplotlib, numpy, pandas, openpyxl, pyperclip, requests, opencv,
+  trimesh/moderngl, …) were already loaded on demand via `ModulesManager`; they
+  are no longer hard requirements. `import mytk` now pulls in only the Python
+  standard library. Install features ahead of time with extras:
+  `pip install mytk[figures]`, `[tables]`, `[images]`, `[video]`, `[view3d]`,
+  `[clipboard]`, `[web]`, `[dnd]`, or `[all]`. (Upgraders who relied on the old
+  transitive installs should add the relevant extra, or `mytk[all]`.)
+
+### Fixed
+- `VideoView` no longer imported OpenCV at module load, which forced `opencv-python`
+  onto every `import mytk`. OpenCV is now loaded only when a `VideoView` is used.
+
 ## [1.2.2] - 2026-06-13
 ### Fixed
 - `View3D` crashed on every render when shown before any geometry was loaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,24 @@ All notable changes to myTk are documented here.
 
 ## [1.3.0] - 2026-06-13
 ### Changed
-- **myTk now installs with no required third-party dependencies.** Heavy/optional
-  modules (matplotlib, numpy, pandas, openpyxl, pyperclip, requests, opencv,
-  trimesh/moderngl, …) were already loaded on demand via `ModulesManager`; they
-  are no longer hard requirements. `import mytk` now pulls in only the Python
-  standard library. Install features ahead of time with extras:
-  `pip install mytk[figures]`, `[tables]`, `[images]`, `[video]`, `[view3d]`,
-  `[clipboard]`, `[web]`, `[dnd]`, or `[all]`. (Upgraders who relied on the old
-  transitive installs should add the relevant extra, or `mytk[all]`.)
+- **Heavy/platform-sensitive features are now optional extras; the default
+  install stays cross-platform.** `pip install mytk` still brings the common,
+  universally pip-installable modules (matplotlib, numpy, pandas, openpyxl,
+  pyperclip, requests, Pillow), but the features that need native libraries,
+  hardware or a GL context are opt-in:
+  - `pip install mytk[video]`  — OpenCV, for `VideoView`
+  - `pip install mytk[view3d]` — trimesh + moderngl, for `View3D`
+  - `pip install mytk[dnd]`    — tkdnd, for drag-and-drop
+  - `pip install mytk[all]`    — all of the above
+  All of these also install on demand at first use (via `ModulesManager`), so
+  nothing breaks if you skip the extra.
+- Dropped `scipy` and `packaging` as declared dependencies — neither is used by
+  the library (`packaging` still arrives transitively via matplotlib).
 
 ### Fixed
-- `VideoView` no longer imported OpenCV at module load, which forced `opencv-python`
-  onto every `import mytk`. OpenCV is now loaded only when a `VideoView` is used.
+- `VideoView` no longer imported OpenCV at module load, so `import mytk` no longer
+  pulls in `opencv-python` (or numpy through it). All third-party modules are now
+  imported lazily — `import mytk` touches only the Python standard library.
 
 ## [1.2.2] - 2026-06-13
 ### Fixed

--- a/mytk/videoview.py
+++ b/mytk/videoview.py
@@ -9,11 +9,6 @@ from .button import Button
 from .modulesmanager import ModulesManager
 from .popupmenu import PopupMenu
 
-try:
-    import cv2
-except ImportError:
-    cv2 = None
-
 
 class VideoView(Base):
     """Live video capture and display widget backed by OpenCV."""
@@ -75,6 +70,8 @@ class VideoView(Base):
         """Return a list of indices for available video capture devices."""
         available_devices = []
         try:
+            import cv2  # optional dependency; absence simply yields no devices
+
             index = 0
             while True:
                 cap = cv2.VideoCapture(index)
@@ -128,8 +125,8 @@ class VideoView(Base):
 
     def start_streaming(self, filepath):
         """Begin writing captured frames to a video file at the given path."""
-        width = self.get_prop_id(cv2.CAP_PROP_FRAME_WIDTH)
-        height = self.get_prop_id(cv2.CAP_PROP_FRAME_HEIGHT)
+        width = self.get_prop_id(self.cv2.CAP_PROP_FRAME_WIDTH)
+        height = self.get_prop_id(self.cv2.CAP_PROP_FRAME_HEIGHT)
         fourcc = self.cv2.VideoWriter_fourcc("I", "4", "2", "0")
         self.videowriter = self.cv2.VideoWriter(
             filepath, fourcc, 20.0, (int(width), int(height)), True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,23 @@ Repository = "https://github.com/DCC-Lab/myTk"
 
 
 [project.optional-dependencies]
-video = ["opencv-python"]
+# Per-feature extras — install only what you use. Each feature also pulls its
+# dependency in on demand at first use (via ModulesManager); these extras are a
+# convenience for provisioning ahead of time.
+figures = ["matplotlib>=3.9", "numpy"]   # Figure, XYPlot, Histogram
+images = ["Pillow"]                        # Image, ImageWithGrid
+tables = ["pandas", "openpyxl"]            # TableView.load_tabular_data (CSV/Excel)
+clipboard = ["pyperclip"]                  # copy-to-clipboard helpers
+web = ["requests"]                         # loading images/data from a URL
+video = ["opencv-python"]                  # VideoView
+view3d = ["trimesh", "numpy", "Pillow", "moderngl"]  # View3D (moderngl backend)
+dnd = ["tkinterdnd2"]                       # drag-and-drop (see mytk.dnd re: Tcl)
 optics = ["raytracing"]
 docs = ["furo", "sphinx", "myst-parser"]
-all = ["mytk[video,optics]"]
+# Everything installable from PyPI on any machine:
+all = ["mytk[figures,images,tables,clipboard,web,video,view3d,dnd]"]
+# What the headless test suite needs to exercise the non-GPU widgets:
+test = ["matplotlib>=3.9", "numpy", "pandas", "openpyxl", "pyperclip", "requests"]
 
 [tool.setuptools_scm]
 write_to = "mytk/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,23 +40,16 @@ Repository = "https://github.com/DCC-Lab/myTk"
 
 
 [project.optional-dependencies]
-# Per-feature extras — install only what you use. Each feature also pulls its
-# dependency in on demand at first use (via ModulesManager); these extras are a
-# convenience for provisioning ahead of time.
-figures = ["matplotlib>=3.9", "numpy"]   # Figure, XYPlot, Histogram
-images = ["Pillow"]                        # Image, ImageWithGrid
-tables = ["pandas", "openpyxl"]            # TableView.load_tabular_data (CSV/Excel)
-clipboard = ["pyperclip"]                  # copy-to-clipboard helpers
-web = ["requests"]                         # loading images/data from a URL
-video = ["opencv-python"]                  # VideoView
-view3d = ["trimesh", "numpy", "Pillow", "moderngl"]  # View3D (moderngl backend)
-dnd = ["tkinterdnd2"]                       # drag-and-drop (see mytk.dnd re: Tcl)
+# Optional, platform-sensitive features kept out of the default install. Each is
+# also installed on demand at first use (via ModulesManager); these extras let
+# you provision them ahead of time.
+video = ["opencv-python"]                            # VideoView (heavy)
+view3d = ["trimesh", "moderngl", "numpy", "Pillow"]  # View3D (needs an OpenGL context)
+dnd = ["tkinterdnd2"]                                # drag-and-drop (tkdnd; Tcl-version sensitive)
 optics = ["raytracing"]
 docs = ["furo", "sphinx", "myst-parser"]
-# Everything installable from PyPI on any machine:
-all = ["mytk[figures,images,tables,clipboard,web,video,view3d,dnd]"]
-# What the headless test suite needs to exercise the non-GPU widgets:
-test = ["matplotlib>=3.9", "numpy", "pandas", "openpyxl", "pyperclip", "requests"]
+# Everything optional, in one go:
+all = ["mytk[video,view3d,dnd,optics]"]
 
 [tool.setuptools_scm]
 write_to = "mytk/_version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
-# myTk has no required third-party dependencies — it runs on the Python
-# standard library (Tkinter) alone. Heavy/optional features (figures, tables,
-# images, video, 3D, drag-and-drop, …) pull their dependencies in on demand via
-# ModulesManager, and are also declared as extras in pyproject.toml, e.g.:
+# Default dependencies: the cross-platform, pip-installable modules that power
+# myTk's common widgets and work everywhere without system libraries or hardware.
+# They are imported lazily (on first use), so `import mytk` stays fast.
 #
-#     pip install mytk[figures]      # matplotlib + numpy
-#     pip install mytk[tables]       # pandas + openpyxl
-#     pip install mytk[all]          # everything runtime
-#
-# This file is intentionally empty of requirements (setuptools reads it for the
-# dynamic `dependencies` field in pyproject.toml).
+# Genuinely optional / platform-sensitive features are NOT here — install them as
+# extras (see pyproject.toml): opencv for VideoView (mytk[video]), the GL stack
+# for View3D (mytk[view3d]), and tkdnd for drag-and-drop (mytk[dnd]).
+matplotlib>=3.9
+numpy
+pandas
+openpyxl
+pyperclip
+requests
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
-matplotlib>=3.9
-numpy
-packaging
-pyperclip
-requests
-scipy
-pandas
-openpyxl
+# myTk has no required third-party dependencies — it runs on the Python
+# standard library (Tkinter) alone. Heavy/optional features (figures, tables,
+# images, video, 3D, drag-and-drop, …) pull their dependencies in on demand via
+# ModulesManager, and are also declared as extras in pyproject.toml, e.g.:
+#
+#     pip install mytk[figures]      # matplotlib + numpy
+#     pip install mytk[tables]       # pandas + openpyxl
+#     pip install mytk[all]          # everything runtime
+#
+# This file is intentionally empty of requirements (setuptools reads it for the
+# dynamic `dependencies` field in pyproject.toml).


### PR DESCRIPTION
Minimize heavy/non-standard dependencies while keeping a sensible **default** install.

## Design (per discussion)
- **Default install** (`pip install mytk`) keeps the common, **cross-platform, pip-installable** modules so the everyday widgets work out of the box: matplotlib, numpy, pandas, openpyxl, pyperclip, requests, Pillow.
- **Optional extras** — only the platform-sensitive / heavy / hardware features:
  - `mytk[video]` — OpenCV (VideoView)
  - `mytk[view3d]` — trimesh + moderngl (View3D; needs a GL context)
  - `mytk[dnd]` — tkdnd (drag-and-drop; Tcl-version sensitive)
  - `mytk[all]` — all of the above (+ optics)
  Each also installs on demand at first use (via `ModulesManager`), so skipping an extra never hard-breaks.

## Changes
- **`VideoView`**: removed the module-level `import cv2` (it forced OpenCV onto every `import mytk`). cv2 is now loaded lazily. **`import mytk` touches only the Python standard library** (verified) — all third-party modules import lazily.
- **`requirements.txt`**: the cross-platform default set; dropped unused `scipy` and `packaging` (the latter still arrives transitively via matplotlib).
- **`pyproject.toml`**: extras trimmed to `video` / `view3d` / `dnd` / `optics` / `docs` / `all`.
- CI installs `pip install -e .` (defaults cover the non-GPU suite); GPU/camera/dnd tests stay gated and skip.

456 tests pass; `import mytk` pulls in zero non-stdlib modules; `.[all]` resolves. CHANGELOG marked 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)