### PR TITLE
release CI: order GitHub Release after PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history + tags so setuptools-scm can derive the version.
           fetch-depth: 0
@@ -52,7 +52,10 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: build
+    # Publish to PyPI first, then create the GitHub Release — so the Release page
+    # only appears once the package is actually live on PyPI (no dangling release
+    # pointing at a version that failed to upload).
+    needs: [build, pypi-publish]
     runs-on: ubuntu-latest
     permissions:
       # Needed to create the release and upload the built artifacts to it.


### PR DESCRIPTION
## Why
The `release.yml` workflow's `pypi-publish` and `github-release` jobs both only depended on `build`, so they ran **in parallel and independently**. That means a GitHub Release could be created even if the PyPI upload failed (or vice-versa), leaving the two out of sync — a dangling Release pointing at a version that isn't on PyPI.

(The git **tag** is always created first — it's the trigger — so "tagged before publish" was never the issue; the gap was between the two *publish* jobs.)

## Change
- `github-release` now `needs: [build, pypi-publish]`, so the order is **tag → build → publish to PyPI → create GitHub Release**. The Release page becomes a reliable signal that the package is live on PyPI.
- Bumped `actions/checkout@v4 → v5` (off the deprecated Node 20 runtime).

## Note on the other Node-20 actions
Left `setup-python`, `upload/download-artifact`, and `softprops/action-gh-release` as-is for now: `release.yml` only runs on a tag push, so it isn't exercised by this PR's CI — a wrong version bump would only surface (and break) at the next release, and I couldn't confirm Node-24 majors exist for them. Happy to do a verified follow-up. The Node-20 removal deadline is Sept 2026.

Workflow-only change; takes effect on the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)