### PR TITLE
CI: install View3D backends (moderngl + pyrender) so the 3D tests run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,17 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          # Default deps cover the non-GPU widgets the suite exercises; the
-          # optional video/view3d/dnd features stay out and their tests skip.
-          pip install -e .
+          # Default deps plus the View3D backend deps (trimesh/moderngl/numpy/
+          # Pillow) so the 3D tests run instead of skipping. GPU-context render
+          # tests still skip gracefully on headless runners; the non-GL View3D
+          # logic (factory, colours, UVs, camera/pan math) is exercised.
+          pip install -e ".[view3d]"
+
+      - name: Install pyrender backend (non-fatal)
+        # The second View3D backend. Best-effort: where no usable pyrender wheel
+        # exists for the runner, its tests stay skipped rather than fail the job.
+        continue-on-error: true
+        run: pip install pyrender
 
       - name: Set up Tk and virtual display (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

CI installed only the **default deps**, so trimesh/moderngl/pyrender were absent and **every View3D test skipped** in CI. This installs the `view3d` extra plus pyrender so both backends' tests actually run.

## Changes (`.github/workflows/tests.yml`)
- `pip install -e ".[view3d]"` — brings trimesh/moderngl/numpy/Pillow so the View3D suite runs.
- A best-effort `pip install pyrender` step (`continue-on-error: true`) — the second backend; if a runner has no usable wheel, those tests stay skipped rather than failing the job.

## What now runs in CI
The **non-GL View3D logic**: factory backend selection, vertex colours, UV/texture detection, ingest, and the camera/pan math.

## What still skips
**GPU-context render tests** skip gracefully on headless runners — they guard context creation (`_ensure_context` / `OffscreenRenderer` in `try/except → skipTest`). Headless Linux has no GL driver, and pyrender's textured upload additionally hits a PyOpenGL `glGenTextures` limitation, so the actual offscreen *render* tests won't execute on CI; their non-GL siblings do.

Validated locally with both backends installed: 472 tests, 8 pre-existing/by-design skips. The CI run on this PR is the real cross-platform check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)