### PR TITLE
ci: bump GitHub Actions to Node 24 compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # Full history + tags so setuptools-scm can derive the version.
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build sdist and wheel
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade twine
           twine check dist/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -40,7 +40,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -61,7 +61,7 @@ jobs:
       # Needed to create the release and upload the built artifacts to it.
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,13 +33,13 @@ jobs:
             python-version: "3.11"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Tags available so setuptools-scm can version the editable install.
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Why
The v1.3.2 release run flagged that several actions still run on **Node.js 20**, which GitHub is force-migrating to Node 24 on **2026-06-16** and removing entirely on **2026-09-16**.

## Changes
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 (tests) / v5 (release) | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |

`upload-artifact@v7` and `download-artifact@v8` share the v4+ artifact backend and interoperate.

## Validation
- `tests.yml` runs on this PR, so the `checkout`/`setup-python` bumps are exercised by CI across the full OS × Python matrix.
- `release.yml` runs only on version tags, so its artifact-action bumps are not exercised here; they take effect on the next `v*` tag. Low risk (input surface unchanged: `name`/`path`).
- Untouched: `pypa/gh-action-pypi-publish@release/v1` and `softprops/action-gh-release@v2` (not flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)