### PR TITLE
docs: remove inline TOC from design page (Furo error box)

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -6,10 +6,6 @@ sits between the narrative :doc:`README <readme>` and the per-module
 :doc:`API Reference <index>`: read the README to see what myTk does, read this
 to understand its structure, then dive into the API for details.
 
-.. contents::
-   :local:
-   :depth: 2
-
 
 Design goals
 ------------


### PR DESCRIPTION
The Design & Architecture page rendered a red Furo error box:

> ERROR: Adding a table of contents in Furo-based documentation is unnecessary, and does not work well with existing styling.

It comes from the `.. contents:: :local:` directive at the top of `design.rst`. Furo already provides a per-page table of contents in the sidebar, so this removes the directive. Build verified: the error box is gone from `design.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)