### PR TITLE
fix: prevent startup window flash at top-left before centering

### DIFF
--- a/mytk/tests/testWindowPosition.py
+++ b/mytk/tests/testWindowPosition.py
@@ -1,0 +1,80 @@
+import unittest
+from tkinter import Tk
+
+import envtest  # noqa: F401  (ensures mytk is importable like the other tests)
+
+from mytk.utils import apply_window_position, parse_geometry
+
+
+class TestApplyWindowPosition(unittest.TestCase):
+    """Regression tests for the startup window-flash fix.
+
+    `apply_window_position` must withdraw the window *before* it touches its
+    geometry, so the window is never mapped at Tk's default (top-left) location
+    before it jumps to the requested spot. This is verified by recording the
+    order in which `withdraw`/`update_idletasks`/`deiconify` are called.
+    """
+
+    def setUp(self):
+        self.root = Tk()
+        self.root.geometry("300x200")
+        self.calls = []
+        # Wrap the state-changing methods to record the call order without
+        # altering their behavior.
+        for name in ("withdraw", "update_idletasks", "deiconify"):
+            original = getattr(self.root, name)
+
+            def recorder(*args, _name=name, _original=original):
+                self.calls.append(_name)
+                return _original(*args)
+
+            setattr(self.root, name, recorder)
+
+    def tearDown(self):
+        try:
+            self.root.destroy()
+        except Exception:
+            pass
+
+    def test_parse_geometry_size_only(self):
+        self.assertEqual(parse_geometry("300x200"), ("300x200", None))
+
+    def test_immediate_branch_withdraws_before_layout(self):
+        # Size known: positioning is applied immediately.
+        apply_window_position(self.root, "center", "300x200")
+
+        # The window must be hidden before any idletasks flush maps it, and
+        # shown again only afterwards.
+        self.assertIn("withdraw", self.calls)
+        self.assertIn("deiconify", self.calls)
+        self.assertLess(
+            self.calls.index("withdraw"),
+            self.calls.index("update_idletasks"),
+            "window must be withdrawn before update_idletasks() maps it",
+        )
+        self.assertLess(
+            self.calls.index("update_idletasks"),
+            self.calls.index("deiconify"),
+            "window must only be shown after it has been positioned",
+        )
+        # And it ends up visible.
+        self.assertEqual(self.root.state(), "normal")
+
+    def test_already_withdrawn_window_stays_hidden(self):
+        # A caller that deliberately withdrew the window (e.g. no_window=True)
+        # must not have it revealed by the positioning helper.
+        self.root.withdraw()
+        self.calls.clear()
+
+        apply_window_position(self.root, "center", "300x200")
+
+        self.assertNotIn("deiconify", self.calls)
+        self.assertEqual(self.root.state(), "withdrawn")
+
+    def test_invalid_position_raises(self):
+        with self.assertRaises(ValueError):
+            apply_window_position(self.root, "middle", "300x200")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mytk/utils.py
+++ b/mytk/utils.py
@@ -34,10 +34,12 @@ def parse_geometry(geometry):
 def apply_window_position(widget, position, size_str=None):
     """Set only the +X+Y offset of a Tk or Toplevel window.
 
-    The window size is never modified.  When *size_str* is provided the
-    offset is computed and applied immediately; otherwise the call is
-    deferred to the first idle tick (after the event loop has laid out all
-    content) and the window is briefly withdrawn to avoid a visible jump.
+    The window size is never modified.  In both cases the window is briefly
+    withdrawn while the offset is computed and applied, so it never flashes at
+    Tk's default (top-left) location before jumping to the requested spot.
+    When *size_str* is provided the offset is applied immediately; otherwise the
+    call is deferred to the first idle tick (after the event loop has laid out
+    all content).
 
     Args:
         widget: A tk.Tk or tk.Toplevel instance.
@@ -67,16 +69,21 @@ def apply_window_position(widget, position, size_str=None):
         x, y = offsets[position]
         widget.geometry(f"+{x}+{y}")  # position only — never overrides size
 
+    # Hide the window while we compute and apply its position so the user never
+    # sees it flash at Tk's default (top-left) location before it jumps to the
+    # requested spot. We restore visibility only after the offset is applied,
+    # and only if the caller had not already withdrawn it on purpose.
+    originally_withdrawn = widget.state() == "withdrawn"
+    widget.withdraw()
+
     if size_str:
         w, h = map(int, size_str.split("x"))
         widget.update_idletasks()
         _apply(w, h)
+        if not originally_withdrawn:
+            widget.deiconify()
     else:
         # Size not yet known; defer until after layout.
-        # Withdraw to avoid a visible jump to the default position.
-        originally_withdrawn = widget.state() == "withdrawn"
-        widget.withdraw()
-
         def _deferred():
             try:
                 if not widget.winfo_exists():


### PR DESCRIPTION
## Problem

Every time an app starts, a window briefly flashes near the top-left corner, disappears, and then the real window appears at its intended (centered) position.

## Cause

When an app is created with a **size-only** geometry plus the default `auto_position="center"` — e.g. `App(geometry="1350x720")`, the common case across the example apps — `apply_window_position()` takes its *immediate* branch:

```python
widget.update_idletasks()   # maps the window at Tk's default top-left
_apply(w, h)                # then jumps it to center
```

`update_idletasks()` maps the window at Tk's default location **before** the centering offset is applied, producing the flash. The *deferred* branch (used when the size isn't yet known) already withdrew the window to avoid exactly this; the immediate branch did not.

## Fix

Withdraw the window in **both** branches before any geometry work, and `deiconify()` only after the offset is applied — and only if the caller hadn't deliberately withdrawn it (e.g. `no_window=True`). A withdrawn window isn't mapped by `update_idletasks()`, so it's never shown until it's already at the correct position. This also smooths the same flash for `Dialog` windows, which share the helper.

## Changes

- `mytk/utils.py` — withdraw in both branches; updated docstring.
- `mytk/tests/testWindowPosition.py` — new regression test asserting the `withdraw → update_idletasks → deiconify` ordering, and that an already-withdrawn window stays hidden.

## Testing

Full suite green: **494 tests pass** (490 prior + 4 new), 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)