### PR TITLE
feat: background_color property + auto-blend canvases into their container

### DIFF
--- a/mytk/base.py
+++ b/mytk/base.py
@@ -57,6 +57,7 @@ class _BaseWidget:
         self.parent = None
         self.value_variable = None
         self._widget_args = {}
+        self._background_color = None
 
         self._grid_kwargs = None
         self.is_environment_valid()
@@ -151,6 +152,7 @@ class _BaseWidget:
             widget = parent.widget
 
         self._bind_destroy_cancel()
+        self._apply_background_color()
 
         column = 0
         if "column" in kwargs:
@@ -251,6 +253,7 @@ class _BaseWidget:
         self.create_widget(master=parent.widget)
         self.parent = parent
         self._bind_destroy_cancel()
+        self._apply_background_color()
 
         if self.widget is not None:
             self.widget.pack(kwargs)
@@ -268,6 +271,7 @@ class _BaseWidget:
         self.create_widget(master=parent.widget)
         self.parent = parent
         self._bind_destroy_cancel()
+        self._apply_background_color()
 
         if self.widget is not None:
             self.widget.place(x=x, y=y, width=width, height=height)
@@ -376,6 +380,118 @@ class _BaseWidget:
             self._widget_args["height"] = value
         else:
             self.widget["height"] = value
+
+    @property
+    def background_color(self):
+        """The widget's background color (a Tk color name or ``#rrggbb`` string).
+
+        Set this to recolor the widget's background. The value is remembered even
+        before the widget exists (myTk creates widgets on placement) and is
+        applied as soon as it is created.
+
+        How it is applied depends on the kind of underlying widget:
+
+        - **Classic Tk widgets** (e.g. the ``Canvas`` behind ``CanvasView`` and
+          the indicators) honor it directly, including the focus-highlight
+          border, so the whole widget takes the color.
+        - **Themed ttk widgets** (``View``/``Box`` and most controls) get a
+          private ``ttk.Style`` configured with this background. This works on
+          the *clam*/*default*/*classic* themes (Linux, Windows). The macOS
+          **aqua** theme draws frames natively and ignores a style background,
+          so setting it on a ``View``/``Box`` has no visible effect there — set
+          it on the classic widget that sits on top (e.g. an indicator) instead.
+
+        Returns:
+            str | None: The configured color, or None if never set.
+        """
+        return self._background_color
+
+    @background_color.setter
+    def background_color(self, value):
+        self._background_color = value
+        self._apply_background_color()
+
+    def _apply_background_color(self):
+        """Apply ``background_color`` to the underlying widget, if both exist.
+
+        Called by the setter and by the placement methods (grid/pack/place)
+        once the widget has been created. No-op when either is missing.
+        """
+        import tkinter.ttk as ttk
+
+        color = self._background_color
+        if color is None or self.widget is None:
+            return
+
+        if isinstance(self.widget, ttk.Widget):
+            # Themed widgets don't take a -background option; route it through a
+            # private style derived from the widget's own class (e.g. TFrame).
+            base_class = self.widget.winfo_class()
+            style_name = f"bg{id(self):x}.{base_class}"
+            ttk.Style().configure(style_name, background=color)
+            with contextlib.suppress(Exception):
+                self.widget.configure(style=style_name)
+        else:
+            # Classic widgets take -background directly; also recolor the
+            # focus-highlight border so it blends instead of framing a square.
+            with contextlib.suppress(Exception):
+                self.widget.configure(background=color)
+            with contextlib.suppress(Exception):
+                self.widget.configure(highlightbackground=color)
+
+    def _inherited_background_color(self):
+        """Best-effort effective background color of this widget's container.
+
+        Used to blend a classic widget (e.g. the ``Canvas`` behind an indicator)
+        into whatever themed container holds it, instead of showing a lighter
+        square. Returns a Tk color *name* whenever possible so the result stays
+        correct when the system appearance changes (light/dark mode).
+
+        - A **classic** parent reports its real background via ``-background``.
+        - On macOS **aqua**, ttk reports ``systemWindowBackgroundColor`` for both
+          a plain ``Frame`` and a ``LabelFrame``, even though aqua draws each
+          nested group box one shade darker. macOS exposes that scale as the
+          dynamic colors ``systemWindowBackgroundColor`` (level 0),
+          ``systemWindowBackgroundColor1`` (level 1), … so we recover the right
+          shade by counting enclosing ``ttk.LabelFrame`` ancestors.
+        - On other themes a ttk parent honors its style background, so we use it.
+
+        Returns:
+            str | None: A color name/value, or None if it cannot be determined.
+        """
+        import tkinter.ttk as ttk
+        from tkinter import TclError
+
+        if self.widget is None:
+            return None
+        try:
+            parent = self.widget.nametowidget(self.widget.winfo_parent())
+        except Exception:
+            return None
+
+        # Classic containers expose their rendered background directly.
+        try:
+            return parent.cget("background")
+        except TclError:
+            pass  # themed widget: no -background option
+
+        try:
+            root = self.widget.winfo_toplevel()
+            if self.widget.tk.call("tk", "windowingsystem") == "aqua":
+                level, node = 0, parent
+                while True:
+                    if node.winfo_class() == "TLabelframe":
+                        level += 1
+                    if node == root:
+                        break
+                    node = node.nametowidget(node.winfo_parent())
+                if level == 0:
+                    return "systemWindowBackgroundColor"
+                return f"systemWindowBackgroundColor{min(level, 7)}"
+            style_name = parent.cget("style") or parent.winfo_class()
+            return ttk.Style().lookup(style_name, "background") or None
+        except Exception:
+            return None
 
     @property
     def is_enabled(self):

--- a/mytk/canvasview.py
+++ b/mytk/canvasview.py
@@ -36,6 +36,16 @@ class CanvasView(Base):
         """Create the underlying tkinter Canvas widget."""
         self.widget = Canvas(master=master, **self._widget_args)
         self.widget.bind("<Configure>", self.on_resize)
+        # A Canvas is opaque, so by default it adopts its container's background
+        # and blends in instead of showing a lighter rectangle (most visible on
+        # macOS inside a ttk.LabelFrame, which aqua draws a shade darker). Skip
+        # this when a background was requested explicitly — either via the
+        # background_color property or a background/bg constructor argument (e.g.
+        # a drawing surface that wants a fixed white background). See
+        # Base.background_color.
+        explicit_bg = "background" in self._widget_args or "bg" in self._widget_args
+        if self._background_color is None and not explicit_bg:
+            self._background_color = self._inherited_background_color()
         self._update_relative_size_basis()
 
     @property

--- a/mytk/example_apps/controlpanel_app.py
+++ b/mytk/example_apps/controlpanel_app.py
@@ -43,6 +43,10 @@ class ControlPanelApp(App):
             self.window, column=1, row=1, columnspan=1, pady=10, padx=10, sticky="new"
         )
 
+        # BooleanIndicator is a classic tk.Canvas, which is opaque; by default it
+        # now adopts its container's background, so the round indicators blend
+        # into the Status box instead of sitting on a lighter square. Pass an
+        # explicit background_color to override (see Base.background_color).
         self.running_indicator = BooleanIndicator()
         self.running_indicator.grid_into(self.status, row=0, column=0, padx=5, pady=5, sticky='e')
         self.bind_property_to_widget_value('acquisition_is_running', self.running_indicator)

--- a/mytk/tests/testBackgroundColor.py
+++ b/mytk/tests/testBackgroundColor.py
@@ -1,0 +1,135 @@
+import unittest
+import tkinter.ttk as ttk
+
+import envtest  # noqa: F401
+
+from mytk import App, View, Box, BooleanIndicator, CanvasView
+
+
+class TestBackgroundColor(envtest.MyTkTestCase):
+    """Tests for Base.background_color across classic and themed widgets."""
+
+    def _rgb(self, widget, color):
+        r, g, b = widget.winfo_rgb(color)
+        return (r, g, b)
+
+    def test_default_is_none(self):
+        view = View(width=50, height=50)
+        self.assertIsNone(view.background_color)
+
+    def test_classic_widget_takes_background_directly(self):
+        # A BooleanIndicator wraps a classic tk.Canvas, which honors -background.
+        ind = BooleanIndicator()
+        ind.grid_into(self.app.window, row=0, column=0)
+        ind.background_color = "#E4E4E4"
+        self.assertEqual(ind.background_color, "#E4E4E4")
+        # The underlying canvas background was actually set.
+        self.assertEqual(
+            self._rgb(ind.widget, ind.widget.cget("background")),
+            self._rgb(ind.widget, "#E4E4E4"),
+        )
+        # The focus-highlight border was recolored to match, so no framed square.
+        self.assertEqual(
+            self._rgb(ind.widget, ind.widget.cget("highlightbackground")),
+            self._rgb(ind.widget, "#E4E4E4"),
+        )
+
+    def test_set_before_placement_is_applied_on_create(self):
+        # Setting the color before the widget exists must apply once placed.
+        ind = BooleanIndicator()
+        ind.background_color = "#123456"
+        self.assertIsNone(ind.widget)  # not created yet
+        ind.grid_into(self.app.window, row=0, column=0)
+        self.assertEqual(
+            self._rgb(ind.widget, ind.widget.cget("background")),
+            self._rgb(ind.widget, "#123456"),
+        )
+
+    def test_themed_widget_uses_private_style(self):
+        # A View wraps a ttk.Frame, which has no -background option; the color
+        # must be routed through a per-instance style instead.
+        view = View(width=80, height=40)
+        view.grid_into(self.app.window, row=0, column=0)
+        view.background_color = "#abcdef"
+        style_name = view.widget.cget("style")
+        self.assertTrue(style_name)  # a custom style was assigned
+        self.assertEqual(
+            self._rgb(view.widget, ttk.Style().lookup(style_name, "background")),
+            self._rgb(view.widget, "#abcdef"),
+        )
+
+    def test_none_is_noop_for_view(self):
+        # A View does not auto-adopt, so leaving it unset must not assign a style.
+        view = View(width=50, height=50)
+        view.grid_into(self.app.window, row=0, column=0)
+        self.assertIsNone(view.background_color)
+
+    def test_indicator_auto_adopts_container_background(self):
+        # With no explicit color, a BooleanIndicator blends into its container.
+        box = Box(label="Status")
+        box.grid_into(self.app.window, row=0, column=0)
+        ind = BooleanIndicator()
+        ind.grid_into(box, row=0, column=0)
+
+        computed = ind._inherited_background_color()
+        if computed is None:
+            self.skipTest("container background not determinable on this theme")
+        # The indicator adopted exactly what the helper computed...
+        self.assertEqual(ind.background_color, computed)
+        # ...and the canvas was actually painted that color.
+        self.assertEqual(
+            self._rgb(ind.widget, ind.widget.cget("background")),
+            self._rgb(ind.widget, computed),
+        )
+
+    def test_indicator_in_labelframe_uses_hierarchical_color_on_aqua(self):
+        # On aqua a LabelFrame interior is one step down the hierarchical window
+        # background scale; the indicator must match that, not the plain window.
+        if self.app.root.tk.call("tk", "windowingsystem") != "aqua":
+            self.skipTest("aqua-specific hierarchical background colors")
+        box = Box(label="Status")
+        box.grid_into(self.app.window, row=0, column=0)
+        ind = BooleanIndicator()
+        ind.grid_into(box, row=0, column=0)
+        self.assertEqual(ind.background_color, "systemWindowBackgroundColor1")
+
+    def test_plain_canvasview_auto_adopts(self):
+        # Auto-adoption applies to every CanvasView, not just indicators.
+        box = Box(label="Status")
+        box.grid_into(self.app.window, row=0, column=0)
+        canvas = CanvasView(width=40, height=40)
+        canvas.grid_into(box, row=0, column=0)
+        computed = canvas._inherited_background_color()
+        if computed is None:
+            self.skipTest("container background not determinable on this theme")
+        self.assertEqual(canvas.background_color, computed)
+
+    def test_explicit_background_kwarg_is_respected(self):
+        # A drawing surface created with background="white" must keep it; the
+        # canvas must not auto-adopt its container's color over the request.
+        box = Box(label="Status")
+        box.grid_into(self.app.window, row=0, column=0)
+        canvas = CanvasView(width=40, height=40, background="white")
+        canvas.grid_into(box, row=0, column=0)
+        self.assertIsNone(canvas.background_color)  # auto-adopt skipped
+        self.assertEqual(
+            self._rgb(canvas.widget, canvas.widget.cget("background")),
+            self._rgb(canvas.widget, "white"),
+        )
+
+    def test_explicit_color_overrides_auto_adopt(self):
+        # A user-set background_color must win over auto-adoption.
+        box = Box(label="Status")
+        box.grid_into(self.app.window, row=0, column=0)
+        ind = BooleanIndicator()
+        ind.background_color = "#ff0000"
+        ind.grid_into(box, row=0, column=0)
+        self.assertEqual(ind.background_color, "#ff0000")
+        self.assertEqual(
+            self._rgb(ind.widget, ind.widget.cget("background")),
+            self._rgb(ind.widget, "#ff0000"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Round status indicators (`BooleanIndicator`) showed a lighter **square** behind the circle when placed inside a `Box` on macOS.

Root cause (measured with exact widget screen coordinates on the aqua theme):

| Surface | Engine | Rendered grey |
|---|---|---|
| Indicator (classic `tk.Canvas`) | flat fill | **#ECECEC (236)** |
| `Box` (`ttk.LabelFrame`) interior | aqua native | **#E4E4E4 (228)** |

Both *report* `systemWindowBackgroundColor` through every Tk API, but aqua **draws** a LabelFrame's group-box interior one shade darker than the flat value a Canvas can produce. A plain `View` (Frame) interior is 236 and blends fine — so the mismatch is specific to the **Box**.

## What this adds

- **`Base.background_color`** — a settable property (Tk color name or `#rrggbb`), remembered before the widget exists and applied on placement:
  - classic widgets → `-background` (+ `-highlightbackground`, so the focus ring blends too);
  - themed ttk widgets → a private per-instance `ttk.Style` (works on clam/default/classic; aqua ignores ttk frame backgrounds, which is *why* the Box itself can't be recolored on macOS and we match the canvas to it instead).
- **`Base._inherited_background_color()`** — the effective container background, returned as a color **name** so it tracks light/dark mode. On aqua it counts enclosing `ttk.LabelFrame` ancestors and maps them onto the hierarchical `systemWindowBackgroundColor{N}` scale (0 → window, 1 → Box, 2 → Box-in-Box, …), recovering the true rendered shade that lookups hide.
- **`CanvasView` auto-adopts** that background by default, so any opaque canvas blends into its container. Opt out with an explicit `background_color`, or a `background=`/`bg=` constructor arg (e.g. `canvas_app`'s white drawing surface — preserved).
- **`controlpanel_app`** needs no manual color now; the indicators blend automatically.

## Verification

Blending confirmed by sampling square-vs-container pixels across every container type:

| Container | Adopted color | Result |
|---|---|---|
| Window directly | `systemWindowBackgroundColor` | ✅ blends |
| `View` (Frame) | `systemWindowBackgroundColor` | ✅ blends |
| `Box` (LabelFrame) | `systemWindowBackgroundColor1` | ✅ blends |
| `Box`-in-`Box` | `systemWindowBackgroundColor2` | ✅ blends |

Full suite green: **504 tests pass** (494 prior + 10 new in `testBackgroundColor.py`), 8 skipped.

## Notes / scope

- Behavioral change is narrow: a canvas in the window or a `View` already rendered 236 and still does; only canvases inside a `Box` now match the darker interior (previously a lighter square). Drawing surfaces with an explicit `background`/`bg` are untouched.
- Dark-mode safe: adoption uses dynamic system color *names*, not frozen RGB values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)