### PR TITLE
Add RemoteControllable capability mixin (RPC control of an App)

### DIFF
--- a/mytk/__init__.py
+++ b/mytk/__init__.py
@@ -39,7 +39,7 @@ from .modulesmanager import ModulesManager
 from .popupmenu import PopupMenu
 from .progressbar import ProgressBar, ProgressBarNotification, ProgressWindow
 from .radiobutton import RadioButton
-from .remote import connect, remote_app
+from .remote import RemoteAppMismatch, connect, remote_app
 from .remotecontrollable import RemoteControllable
 from .tableview import TableView
 from .tabulardata import PostponeChangeCalls, TabularData
@@ -89,6 +89,7 @@ __all__ = [  # noqa: F405
     "ProgressBarNotification",
     "ProgressWindow",
     "RadioButton",
+    "RemoteAppMismatch",
     "RemoteControllable",
     "SVGImage",
     "SimpleDialog",

--- a/mytk/__init__.py
+++ b/mytk/__init__.py
@@ -39,6 +39,8 @@ from .modulesmanager import ModulesManager
 from .popupmenu import PopupMenu
 from .progressbar import ProgressBar, ProgressBarNotification, ProgressWindow
 from .radiobutton import RadioButton
+from .remote import connect, remote_app
+from .remotecontrollable import RemoteControllable
 from .tableview import TableView
 from .tabulardata import PostponeChangeCalls, TabularData
 from .view3d import View3D, View3DModernGL, View3DPyrender
@@ -87,6 +89,7 @@ __all__ = [  # noqa: F405
     "ProgressBarNotification",
     "ProgressWindow",
     "RadioButton",
+    "RemoteControllable",
     "SVGImage",
     "SimpleDialog",
     "Slider",
@@ -100,6 +103,8 @@ __all__ = [  # noqa: F405
     "View3DPyrender",
     "Window",
     "XYPlot",
+    "connect",
+    "remote_app",
     "tkFont",
     "ttk",
     # Re-exported tkinter variables and classes

--- a/mytk/remote.py
+++ b/mytk/remote.py
@@ -1,0 +1,88 @@
+"""remote.py — Lightweight client access to a running myTk App's remote API.
+
+An `App` that mixes in :class:`~mytk.remotecontrollable.RemoteControllable` can
+expose functions with the ``@app.remote`` decorator and serve them with
+``app.start_remote()``. From another process, connect and call them by name::
+
+    import mytk
+    mytk.remote_app.blabla(1, 2)          # default localhost:8777
+    far = mytk.connect("192.168.1.5", 9000)
+    far.blabla(1, 2)
+
+The transport is stdlib XML-RPC, so arguments and return values must be
+XML-RPC serializable (numbers, str, bool, None, list, dict).
+"""
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8777
+
+
+def connect(host=DEFAULT_HOST, port=DEFAULT_PORT):
+    """Return a proxy to a myTk remote server.
+
+    Exposed functions are called as attributes of the proxy::
+
+        proxy = connect("127.0.0.1", 8777)
+        proxy.blabla(1, 2)
+
+    Args:
+        host (str): Server host. Defaults to localhost.
+        port (int): Server port. Defaults to 8777.
+
+    Returns:
+        xmlrpc.client.ServerProxy: A proxy whose attribute calls become
+        remote calls.
+    """
+    from xmlrpc.client import ServerProxy
+
+    return ServerProxy(f"http://{host}:{port}/", allow_none=True)
+
+
+class RemoteAppProxy:
+    """Module-level proxy that connects on first use.
+
+    Lets ``mytk.remote_app.blabla()`` work without an explicit ``connect()``.
+    Defaults to localhost:8777; call :meth:`configure` to target another
+    server before the first call.
+
+    Every attribute access that is not one of this proxy's own names is
+    forwarded to the remote server as a callable, so avoid exposing remote
+    functions literally named ``host``, ``port``, ``proxy``, or ``configure``.
+    """
+
+    def __init__(self):
+        self.host = DEFAULT_HOST
+        self.port = DEFAULT_PORT
+        self.proxy = None
+
+    def configure(self, host=None, port=None):
+        """Point the proxy at a different server, dropping any open connection.
+
+        Args:
+            host (str, optional): New host. Unchanged if None.
+            port (int, optional): New port. Unchanged if None.
+        """
+        if host is not None:
+            self.host = host
+        if port is not None:
+            self.port = port
+        self.proxy = None
+
+    def __getattr__(self, name):
+        # __getattr__ only runs for names not found normally. Dunders and other
+        # underscore-prefixed names are Python internals (copy/pickle probes),
+        # never remote calls. Reach into __dict__ for our own state so this can
+        # never recurse, even before __init__ has run.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        proxy = self.__dict__.get("proxy")
+        if proxy is None:
+            proxy = connect(
+                self.__dict__.get("host", DEFAULT_HOST),
+                self.__dict__.get("port", DEFAULT_PORT),
+            )
+            self.proxy = proxy
+        return getattr(proxy, name)
+
+
+remote_app = RemoteAppProxy()

--- a/mytk/remote.py
+++ b/mytk/remote.py
@@ -16,8 +16,21 @@ XML-RPC serializable (numbers, str, bool, None, list, dict).
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8777
 
+# Methods every RemoteControllable server auto-exposes (see start_remote); they
+# are not listed by remote_signatures (which reports user functions only), so
+# the client must treat them as always available.
+BUILTIN_REMOTE_METHODS = ("remote_signatures", "remote_app_name")
 
-def connect(host=DEFAULT_HOST, port=DEFAULT_PORT):
+
+class RemoteAppMismatch(Exception):
+    """Raised when a server's app name does not match the expected one.
+
+    Lets a client be sure it reached the intended app when several apps run on
+    the same machine (see :meth:`mytk.remotecontrollable.RemoteControllable.remote_app_name`).
+    """
+
+
+def connect(host=DEFAULT_HOST, port=DEFAULT_PORT, app_name=None):
     """Return a proxy to a myTk remote server.
 
     Exposed functions are called as attributes of the proxy::
@@ -28,14 +41,28 @@ def connect(host=DEFAULT_HOST, port=DEFAULT_PORT):
     Args:
         host (str): Server host. Defaults to localhost.
         port (int): Server port. Defaults to 8777.
+        app_name (str, optional): If given, verify the server reports this name
+            and raise :class:`RemoteAppMismatch` otherwise. Useful when several
+            apps run on the same machine.
 
     Returns:
         xmlrpc.client.ServerProxy: A proxy whose attribute calls become
         remote calls.
+
+    Raises:
+        RemoteAppMismatch: If ``app_name`` is given and does not match.
     """
     from xmlrpc.client import ServerProxy
 
-    return ServerProxy(f"http://{host}:{port}/", allow_none=True)
+    proxy = ServerProxy(f"http://{host}:{port}/", allow_none=True)
+    if app_name is not None:
+        actual = proxy.remote_app_name()
+        if actual != app_name:
+            raise RemoteAppMismatch(
+                f"Expected app {app_name!r} at {host}:{port}, "
+                f"but it identifies as {actual!r}"
+            )
+    return proxy
 
 
 class RemoteAppProxy:
@@ -45,28 +72,40 @@ class RemoteAppProxy:
     Defaults to localhost:8777; call :meth:`configure` to target another
     server before the first call.
 
+    On first use it fetches the server's exposed API (``remote_signatures``)
+    and validates every call against it, so an unknown method raises a clear
+    ``AttributeError`` here instead of a cryptic XML-RPC fault when called.
+
     Every attribute access that is not one of this proxy's own names is
-    forwarded to the remote server as a callable, so avoid exposing remote
-    functions literally named ``host``, ``port``, ``proxy``, or ``configure``.
+    forwarded to the remote server, so avoid exposing remote functions literally
+    named ``host``, ``port``, ``proxy``, ``app_name``, ``signatures``, or
+    ``configure``.
     """
 
     def __init__(self):
         self.host = DEFAULT_HOST
         self.port = DEFAULT_PORT
+        self.app_name = None
         self.proxy = None
+        self.signatures = None
 
-    def configure(self, host=None, port=None):
+    def configure(self, host=None, port=None, app_name=None):
         """Point the proxy at a different server, dropping any open connection.
 
         Args:
             host (str, optional): New host. Unchanged if None.
             port (int, optional): New port. Unchanged if None.
+            app_name (str, optional): Expected server identity to verify on the
+                next connection. Unchanged if None.
         """
         if host is not None:
             self.host = host
         if port is not None:
             self.port = port
+        if app_name is not None:
+            self.app_name = app_name
         self.proxy = None
+        self.signatures = None
 
     def __getattr__(self, name):
         # __getattr__ only runs for names not found normally. Dunders and other
@@ -75,13 +114,28 @@ class RemoteAppProxy:
         # never recurse, even before __init__ has run.
         if name.startswith("_"):
             raise AttributeError(name)
+
         proxy = self.__dict__.get("proxy")
         if proxy is None:
             proxy = connect(
                 self.__dict__.get("host", DEFAULT_HOST),
                 self.__dict__.get("port", DEFAULT_PORT),
+                self.__dict__.get("app_name"),
             )
             self.proxy = proxy
+            self.signatures = None  # refetch for the new connection
+
+        available = self.__dict__.get("signatures")
+        if available is None:
+            available = proxy.remote_signatures()
+            self.signatures = available
+
+        if name not in available and name not in BUILTIN_REMOTE_METHODS:
+            offered = sorted(set(available) | set(BUILTIN_REMOTE_METHODS))
+            raise AttributeError(
+                f"{name!r} is not exposed by the remote app. "
+                f"Available: {offered}"
+            )
         return getattr(proxy, name)
 
 

--- a/mytk/remotecontrollable.py
+++ b/mytk/remotecontrollable.py
@@ -46,6 +46,7 @@ class RemoteControllable:
         self.remote_functions = {}
         self.remote_server = None
         self.remote_call_timeout = 30
+        self.app_name = None
         super().__init__(*args, **kwargs)  # cooperative!
 
     def remote(self, fct=None, *, name=None):
@@ -89,7 +90,19 @@ class RemoteControllable:
             for name, fct in self.remote_functions.items()
         }
 
-    def start_remote(self, port=8777, host="127.0.0.1"):
+    def remote_app_name(self):
+        """Returns this app's name so a client can confirm it reached the
+        intended server when several apps run on the same machine.
+
+        Exposed remotely and used by :func:`mytk.remote.connect` when its
+        ``app_name`` argument is given.
+
+        Returns:
+            str | None: The app name (see :meth:`start_remote`).
+        """
+        return self.app_name
+
+    def start_remote(self, port=8777, host="127.0.0.1", app_name=None):
         """Starts a background server exposing the functions registered with
         :meth:`remote`.
 
@@ -100,6 +113,9 @@ class RemoteControllable:
         Args:
             port (int): Port to bind. Use 0 to let the OS pick a free port.
             host (str): Interface to bind. Defaults to localhost.
+            app_name (str, optional): Identity clients can verify (see
+                :meth:`remote_app_name`). Defaults to ``self.app_name`` if
+                already set, otherwise the App's ``name``.
 
         Returns:
             int: The port actually bound (useful with ``port=0``).
@@ -110,15 +126,23 @@ class RemoteControllable:
         if self.remote_server is not None:
             return self.remote_server.server_address[1]
 
+        if app_name is not None:
+            self.app_name = app_name
+        if self.app_name is None:
+            self.app_name = getattr(self, "name", None)
+
         server = SimpleXMLRPCServer(
             (host, port), allow_none=True, logRequests=False
         )
         for exposed_name, fct in self.remote_functions.items():
             server.register_function(self.remote_wrapper(fct), exposed_name)
 
-        # Always let clients introspect the exposed API.
+        # Always let clients introspect the exposed API and verify identity.
         server.register_function(
             self.remote_wrapper(self.remote_signatures), "remote_signatures"
+        )
+        server.register_function(
+            self.remote_wrapper(self.remote_app_name), "remote_app_name"
         )
 
         self.remote_server = server

--- a/mytk/remotecontrollable.py
+++ b/mytk/remotecontrollable.py
@@ -1,0 +1,173 @@
+"""remotecontrollable.py — Capability mixin exposing an App over RPC.
+
+`RemoteControllable` is a capability mixin, in the same spirit as
+`EventCapable` and `DragAndDropCapable`. Mix it into an `App` subclass to let
+external processes call selected functions on the running application::
+
+    from mytk import App, RemoteControllable
+
+    class MyApp(App, RemoteControllable):
+        pass
+
+    app = MyApp(name="Server")
+
+    @app.remote
+    def add(a, b):
+        return a + b
+
+    app.start_remote()      # localhost:8777
+    app.mainloop()
+
+Clients connect with ``mytk.connect(...)`` or ``mytk.remote_app`` (see
+:mod:`mytk.remote`). The transport is stdlib XML-RPC, so arguments and return
+values must be XML-RPC serializable (numbers, str, bool, None, list, dict).
+
+The host class must provide ``schedule_on_main_thread`` and ``root`` (both are
+supplied by `App`): every call is marshaled onto the Tk main thread, so exposed
+functions may safely touch widgets.
+"""
+
+from contextlib import suppress
+
+
+class RemoteControllable:
+    """Mixin adding a remote-procedure-call server to an `App`.
+
+    Designed to be combined with `App`, which provides the Tk main-thread queue
+    (`schedule_on_main_thread`) and the root window (`root`). Not usable on its
+    own. Works in either inheritance order — ``class MyApp(App,
+    RemoteControllable)`` or ``class MyApp(RemoteControllable, App)`` — because
+    it cooperates through ``super().__init__`` and shuts the server down from a
+    root ``<Destroy>`` binding rather than by overriding ``quit``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize remote-call state for cooperative multiple inheritance."""
+        self.remote_functions = {}
+        self.remote_server = None
+        self.remote_call_timeout = 30
+        super().__init__(*args, **kwargs)  # cooperative!
+
+    def remote(self, fct=None, *, name=None):
+        """Exposes a function for remote invocation by clients.
+
+        Usable as a decorator (``@app.remote``) or directly
+        (``app.remote(fct)``). Only exposed functions are reachable. The call
+        runs on the Tk main thread, so it may safely touch widgets. Arguments
+        and the return value must be XML-RPC serializable (numbers, str, bool,
+        None, list, dict).
+
+        Args:
+            fct (callable, optional): The function to expose. Omitted when used
+                as a bare ``@app.remote`` decorator.
+            name (str, optional): Name clients use to call it. Defaults to the
+                function's own name.
+
+        Returns:
+            callable: The function, so it can be used as a decorator.
+        """
+        if fct is None:
+            return lambda f: self.remote(f, name=name)
+        self.remote_functions[name or fct.__name__] = fct
+        return fct
+
+    def remote_signatures(self):
+        """Returns the signature of every exposed function.
+
+        Useful for discovering the remote API. Keys are the names clients use;
+        values are signature strings such as ``"(a, b)"``. Also exposed
+        remotely, so a client can call ``remote_app.remote_signatures()`` to
+        introspect the server.
+
+        Returns:
+            dict[str, str]: Mapping of function name to its signature string.
+        """
+        import inspect
+
+        return {
+            name: str(inspect.signature(fct))
+            for name, fct in self.remote_functions.items()
+        }
+
+    def start_remote(self, port=8777, host="127.0.0.1"):
+        """Starts a background server exposing the functions registered with
+        :meth:`remote`.
+
+        Localhost-only by default. The server runs in a daemon thread; each
+        call is marshaled onto the Tk main thread and its return value sent
+        back to the client. Safe to call once; further calls are no-ops.
+
+        Args:
+            port (int): Port to bind. Use 0 to let the OS pick a free port.
+            host (str): Interface to bind. Defaults to localhost.
+
+        Returns:
+            int: The port actually bound (useful with ``port=0``).
+        """
+        import threading
+        from xmlrpc.server import SimpleXMLRPCServer
+
+        if self.remote_server is not None:
+            return self.remote_server.server_address[1]
+
+        server = SimpleXMLRPCServer(
+            (host, port), allow_none=True, logRequests=False
+        )
+        for exposed_name, fct in self.remote_functions.items():
+            server.register_function(self.remote_wrapper(fct), exposed_name)
+
+        # Always let clients introspect the exposed API.
+        server.register_function(
+            self.remote_wrapper(self.remote_signatures), "remote_signatures"
+        )
+
+        self.remote_server = server
+        thread = threading.Thread(
+            target=server.serve_forever, name="mytk-remote", daemon=True
+        )
+        thread.start()
+
+        # Stop the server when the app window goes away, without overriding
+        # quit() (keeps this independent of the inheritance order). add="+"
+        # preserves App's own root <Destroy> handler.
+        self.root.bind("<Destroy>", self.stop_remote_on_destroy, add="+")
+        return server.server_address[1]
+
+    def stop_remote(self):
+        """Shuts down the remote server if it is running."""
+        if self.remote_server is not None:
+            server, self.remote_server = self.remote_server, None
+            with suppress(Exception):
+                server.shutdown()
+            with suppress(Exception):
+                server.server_close()
+
+    def stop_remote_on_destroy(self, event):
+        """Root <Destroy> handler: shut the server down with the window."""
+        if event.widget is self.root:
+            self.stop_remote()
+
+    def remote_wrapper(self, fct):
+        """Wraps an exposed function so the RPC thread runs it on the main
+        thread and blocks for its result."""
+
+        def wrapper(*args):
+            return self.call_on_main_thread(fct, args)
+
+        return wrapper
+
+    def call_on_main_thread(self, fct, args=(), kwargs=None):
+        """Runs `fct` on the Tk main thread and returns its result, blocking
+        the calling (RPC) thread. Exceptions propagate to the caller."""
+        from concurrent.futures import Future
+
+        future = Future()
+
+        def task():
+            try:
+                future.set_result(fct(*args, **(kwargs or {})))
+            except Exception as exc:
+                future.set_exception(exc)
+
+        self.schedule_on_main_thread(task)
+        return future.result(timeout=self.remote_call_timeout)

--- a/mytk/tests/testRemote.py
+++ b/mytk/tests/testRemote.py
@@ -116,6 +116,72 @@ class TestRemoteServer(unittest.TestCase):
         self._run_with_client(client_call)
         self.assertEqual(self.result["add"], "(a, b)")
 
+    def test_remote_app_name(self):
+        port = self.app.start_remote(port=0, app_name="Server-A")
+
+        def client_call():
+            self.result = mytk.connect(port=port).remote_app_name()
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, "Server-A")
+
+    def test_remote_app_name_defaults_to_app_name(self):
+        # No explicit app_name -> falls back to the App's name.
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            self.result = mytk.connect(port=port).remote_app_name()
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, self.app.name)
+
+    def test_connect_matching_app_name_ok(self):
+        @self.app.remote
+        def add(a, b):
+            return a + b
+
+        port = self.app.start_remote(port=0, app_name="Server-A")
+
+        def client_call():
+            self.result = mytk.connect(port=port, app_name="Server-A").add(1, 1)
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, 2)
+
+    def test_connect_wrong_app_name_raises(self):
+        port = self.app.start_remote(port=0, app_name="Server-A")
+
+        def client_call():
+            try:
+                mytk.connect(port=port, app_name="Server-B")
+            except mytk.RemoteAppMismatch:
+                self.blocked = True
+
+        self._run_with_client(client_call)
+        self.assertTrue(self.blocked)
+
+    def test_proxy_validates_against_signatures(self):
+        @self.app.remote
+        def add(a, b):
+            return a + b
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            from mytk.remote import RemoteAppProxy
+
+            proxy = RemoteAppProxy()
+            proxy.configure(port=port)
+            self.result = proxy.add(2, 3)  # known -> forwarded
+            try:
+                proxy.nope()  # unknown -> caught before the network call
+            except AttributeError:
+                self.blocked = True
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, 5)
+        self.assertTrue(self.blocked)
+
     def test_unregistered_function_not_exposed(self):
         @self.app.remote
         def ping():

--- a/mytk/tests/testRemote.py
+++ b/mytk/tests/testRemote.py
@@ -1,0 +1,154 @@
+import threading
+import unittest
+import xmlrpc.client
+
+import mytk
+from mytk import App, RemoteControllable
+
+
+class RemoteApp(App, RemoteControllable):
+    """An App made controllable by mixing in the capability."""
+
+
+class TestRemoteRegistration(unittest.TestCase):
+    """Pure registration behavior, no server or mainloop needed."""
+
+    def setUp(self):
+        self.app = RemoteApp(name=self.id())
+
+    def tearDown(self):
+        self.app.quit()
+
+    def test_app_is_remote_controllable(self):
+        self.assertIsInstance(self.app, RemoteControllable)
+
+    def test_remote_as_decorator(self):
+        @self.app.remote
+        def foo():
+            return 1
+
+        self.assertIn("foo", self.app.remote_functions)
+        self.assertIs(self.app.remote_functions["foo"], foo)
+
+    def test_remote_direct_call_with_name(self):
+        def bar():
+            return 2
+
+        returned = self.app.remote(bar, name="renamed")
+        self.assertIs(returned, bar)
+        self.assertIn("renamed", self.app.remote_functions)
+        self.assertNotIn("bar", self.app.remote_functions)
+
+    def test_remote_signatures(self):
+        @self.app.remote
+        def add(a, b):
+            return a + b
+
+        @self.app.remote
+        def greet(name, greeting="hello"):
+            return f"{greeting}, {name}"
+
+        signatures = self.app.remote_signatures()
+        self.assertEqual(signatures["add"], "(a, b)")
+        self.assertEqual(signatures["greet"], "(name, greeting='hello')")
+
+
+class TestRemoteServer(unittest.TestCase):
+    """End-to-end: a client thread calls the server while the app runs."""
+
+    def setUp(self):
+        self.app = RemoteApp(name=self.id())
+        self.result = None
+        self.title_result = None
+        self.blocked = False
+        self.fault_message = None
+
+    def tearDown(self):
+        self.app.quit()
+
+    def _run_with_client(self, client_call, timeout=1500):
+        # Client runs off the main thread; the Tk mainloop drains the queue.
+        thread = threading.Thread(target=client_call)
+        self.app.after(int(timeout / 4), thread.start)
+        self.app.after(timeout, self.app.quit)
+        self.app.mainloop()
+        thread.join(timeout=3)
+
+    def test_remote_call_returns_value(self):
+        @self.app.remote
+        def add(a, b):
+            return a + b
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            self.result = mytk.connect(port=port).add(2, 3)
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, 5)
+
+    def test_remote_runs_on_main_thread(self):
+        # Touching a Tk widget only works on the main thread; getting the
+        # value back proves the call was marshaled there.
+        @self.app.remote
+        def set_title(text):
+            self.app.window.widget.title(text)
+            return self.app.window.widget.title()
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            self.title_result = mytk.connect(port=port).set_title("hello-remote")
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.title_result, "hello-remote")
+
+    def test_remote_signatures_over_the_wire(self):
+        @self.app.remote
+        def add(a, b):
+            return a + b
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            self.result = mytk.connect(port=port).remote_signatures()
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result["add"], "(a, b)")
+
+    def test_unregistered_function_not_exposed(self):
+        @self.app.remote
+        def ping():
+            return "pong"
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            try:
+                mytk.connect(port=port).not_exposed()
+            except xmlrpc.client.Fault:
+                self.blocked = True
+
+        self._run_with_client(client_call)
+        self.assertTrue(self.blocked)
+
+    def test_remote_exception_propagates(self):
+        @self.app.remote
+        def boom():
+            raise ValueError("nope")
+
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            try:
+                mytk.connect(port=port).boom()
+            except xmlrpc.client.Fault as exc:
+                self.fault_message = str(exc)
+
+        self._run_with_client(client_call)
+        self.assertIsNotNone(self.fault_message)
+        self.assertIn("nope", self.fault_message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an **opt-in capability mixin**, `RemoteControllable`, in the same spirit as `EventCapable` and `DragAndDropCapable`. Mix it into an `App` subclass to let another process call selected functions on the running application. Pure stdlib (`xmlrpc`), **no new dependencies**, imported lazily.

```python
from mytk import App, RemoteControllable

class MyApp(App, RemoteControllable):
    pass

app = MyApp(name="Acquisition")

@app.remote
def add(a, b):
    return a + b

app.start_remote()      # localhost:8777
app.mainloop()
```

Client (any process):
```python
import mytk
mytk.remote_app.add(2, 3)                   # -> 5   (default localhost:8777)
mytk.remote_app.remote_signatures()         # -> {'add': '(a, b)'}
far = mytk.connect("192.168.1.5", 9000)     # explicit target
```

## How it works

- **Main-thread affinity:** each remote call is marshaled onto the Tk main thread via a `Future` + the existing `schedule_on_main_thread`, so exposed functions may safely touch widgets. The return value (or exception) flows back to the client.
- **Discovery:** `remote_signatures()` returns `{name: "(params)"}` for every exposed function and is auto-exposed, so clients can introspect the server.
- **Identity:** `app_name` (defaults to the App's `name`) is exposed via `remote_app_name()`. `connect(app_name=...)` verifies it and raises `RemoteAppMismatch` on a mismatch — so you can be sure you reached the intended app when several run on one machine.
- **Client-side validation:** `mytk.remote_app` fetches `remote_signatures()` on first use and validates every call against it, so an unknown method raises a clear `AttributeError` locally instead of a cryptic XML-RPC fault at call time.
- **Order-independent:** works as `class MyApp(App, RemoteControllable)` or `class MyApp(RemoteControllable, App)`. Teardown is done from a root `<Destroy>` binding rather than by overriding `quit()`, so it needs no cooperation from `App` and doesn't depend on MRO order.
- **Lazy client proxy:** `mytk.remote_app` is a `RemoteAppProxy` that connects only on first use — importing mytk never opens a socket.

## Design notes / scope

- **Localhost-only, no auth** by default. Binding to a network interface would need a shared secret (XML-RPC has none built in).
- **Serialization limit:** arguments and return values must be XML-RPC types (numbers, str, bool, None, list, dict, bytes). Can't return a live widget.
- **`App` is untouched** — no remote code leaks into the base class; the capability is entirely opt-in.

## Tests

New `mytk/tests/testRemote.py` (14 tests) using a `RemoteApp(App, RemoteControllable)` subclass: registration, return values, main-thread affinity, the not-exposed allowlist, exception propagation, signature discovery (local + over the wire), app-name identity/defaulting, `connect` verification (match + `RemoteAppMismatch`), and proxy validation against the exposed API. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)