### PR TITLE
Add @remote_command for exposing class-body methods over RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to myTk are documented here.
 
+## [1.6.1]
+### Added
+- **`remote_command`** decorator and
+  **`RemoteControllable.register_remote_commands()`** for exposing methods
+  declared in a class body. `@app.remote` cannot decorate methods at
+  class-definition time (there is no live app yet), so tag them with
+  `@remote_command` (bare or `@remote_command(name="...")`) and call
+  `app.register_remote_commands()` once to register them all. Purely additive:
+  existing `self.remote(...)` / `@app.remote` usage is unchanged.
+
 ## [1.4.0] - 2026-06-18
 ### Added
 - **`SVGImage`** — a widget that displays an SVG document, rasterized with the

--- a/mytk/__init__.py
+++ b/mytk/__init__.py
@@ -40,7 +40,7 @@ from .popupmenu import PopupMenu
 from .progressbar import ProgressBar, ProgressBarNotification, ProgressWindow
 from .radiobutton import RadioButton
 from .remote import RemoteAppMismatch, connect, remote_app
-from .remotecontrollable import RemoteControllable
+from .remotecontrollable import RemoteControllable, remote_command
 from .tableview import TableView
 from .tabulardata import PostponeChangeCalls, TabularData
 from .view3d import View3D, View3DModernGL, View3DPyrender
@@ -106,6 +106,7 @@ __all__ = [  # noqa: F405
     "XYPlot",
     "connect",
     "remote_app",
+    "remote_command",
     "tkFont",
     "ttk",
     # Re-exported tkinter variables and classes

--- a/mytk/remotecontrollable.py
+++ b/mytk/remotecontrollable.py
@@ -18,6 +18,25 @@ external processes call selected functions on the running application::
     app.start_remote()      # localhost:8777
     app.mainloop()
 
+Methods declared in a class body cannot use ``@app.remote`` (there is no live
+app yet); tag them with ``@remote_command`` and register them in one call::
+
+    from mytk import App, RemoteControllable, remote_command
+
+    class MyApp(App, RemoteControllable):
+        @remote_command
+        def turn_on(self):
+            ...
+
+        @remote_command(name="status")
+        def read_status(self):
+            return {"on": True}
+
+    app = MyApp(name="Server")
+    app.register_remote_commands()   # expose every tagged method
+    app.start_remote()
+    app.mainloop()
+
 Clients connect with ``mytk.connect(...)`` or ``mytk.remote_app`` (see
 :mod:`mytk.remote`). The transport is stdlib XML-RPC, so arguments and return
 values must be XML-RPC serializable (numbers, str, bool, None, list, dict).
@@ -28,6 +47,39 @@ functions may safely touch widgets.
 """
 
 from contextlib import suppress
+
+
+def remote_command(fct=None, *, name=None):
+    """Mark a method for remote exposure by :class:`RemoteControllable`.
+
+    A *tag* only: it records the RPC name on the function and returns it
+    unchanged. Registration happens at runtime in
+    :meth:`RemoteControllable.register_remote_commands`, once an instance (and
+    its ``remote`` registry) exists — ``@app.remote`` cannot be used in a class
+    body because there is no live app there yet.
+
+    Use bare, or with an explicit name::
+
+        class MyApp(App, RemoteControllable):
+            @remote_command
+            def turn_on(self): ...
+
+            @remote_command(name="status")
+            def read_status(self): ...
+
+    Args:
+        fct (callable, optional): The method to tag. Omitted when used as
+            ``@remote_command(name=...)``.
+        name (str, optional): Name clients call it by. Defaults to the
+            method's own name.
+
+    Returns:
+        callable: The method, unchanged, so it works as a decorator.
+    """
+    if fct is None:
+        return lambda f: remote_command(f, name=name)
+    fct._remote_name = name or fct.__name__
+    return fct
 
 
 class RemoteControllable:
@@ -71,6 +123,26 @@ class RemoteControllable:
             return lambda f: self.remote(f, name=name)
         self.remote_functions[name or fct.__name__] = fct
         return fct
+
+    def register_remote_commands(self):
+        """Expose every method tagged with :func:`remote_command`.
+
+        Scans the class (not the instance, so property getters are never
+        triggered) for methods carrying the ``@remote_command`` marker and
+        registers each with :meth:`remote`. Call once, before or after
+        :meth:`start_remote`.
+
+        Returns:
+            list[str]: The RPC names that were registered.
+        """
+        registered = []
+        for attr_name in dir(type(self)):
+            tagged = getattr(type(self), attr_name, None)
+            remote_name = getattr(tagged, "_remote_name", None)
+            if remote_name is not None:
+                self.remote(getattr(self, attr_name), name=remote_name)
+                registered.append(remote_name)
+        return registered
 
     def remote_signatures(self):
         """Returns the signature of every exposed function.

--- a/mytk/tests/testRemote.py
+++ b/mytk/tests/testRemote.py
@@ -3,7 +3,7 @@ import unittest
 import xmlrpc.client
 
 import mytk
-from mytk import App, RemoteControllable
+from mytk import App, RemoteControllable, remote_command
 
 
 class RemoteApp(App, RemoteControllable):
@@ -214,6 +214,84 @@ class TestRemoteServer(unittest.TestCase):
         self._run_with_client(client_call)
         self.assertIsNotNone(self.fault_message)
         self.assertIn("nope", self.fault_message)
+
+
+class CommandApp(App, RemoteControllable):
+    """An App exposing methods declared in its class body via @remote_command."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.flag = False
+
+    @remote_command
+    def flip(self):
+        self.flag = True
+        return self.flag
+
+    @remote_command(name="status")
+    def read_status(self):
+        return {"flag": self.flag}
+
+    @property
+    def boom(self):  # scanning must never invoke this getter
+        raise RuntimeError("property getter triggered during scan")
+
+
+class TestRemoteCommands(unittest.TestCase):
+    """Class-body @remote_command markers registered via register_remote_commands()."""
+
+    def setUp(self):
+        self.app = CommandApp(name=self.id())
+        self.result = None
+
+    def tearDown(self):
+        self.app.quit()
+
+    def _run_with_client(self, client_call, timeout=1500):
+        thread = threading.Thread(target=client_call)
+        self.app.after(int(timeout / 4), thread.start)
+        self.app.after(timeout, self.app.quit)
+        self.app.mainloop()
+        thread.join(timeout=3)
+
+    def test_register_scans_class_without_triggering_properties(self):
+        # Sanity: the property really does raise when its getter runs...
+        with self.assertRaises(RuntimeError):
+            _ = self.app.boom
+        # ...yet scanning the class to register commands must not touch it.
+        names = self.app.register_remote_commands()
+        self.assertEqual(set(names), {"flip", "status"})
+
+    def test_bare_command_uses_method_name(self):
+        self.app.register_remote_commands()
+        self.assertIn("flip", self.app.remote_signatures())
+
+    def test_named_command_uses_custom_name(self):
+        self.app.register_remote_commands()
+        signatures = self.app.remote_signatures()
+        self.assertIn("status", signatures)
+        self.assertNotIn("read_status", signatures)
+
+    def test_command_round_trip(self):
+        self.app.register_remote_commands()
+        port = self.app.start_remote(port=0)
+
+        def client_call():
+            proxy = mytk.connect(port=port)
+            self.result = (proxy.flip(), proxy.status())
+
+        self._run_with_client(client_call)
+        self.assertEqual(self.result, (True, {"flag": True}))
+
+    def test_remote_still_works_alongside_commands(self):
+        # Backward-compat: imperative registration coexists with tagged methods.
+        self.app.register_remote_commands()
+
+        @self.app.remote
+        def extra():
+            return 42
+
+        self.assertEqual({"flip", "status", "extra"}, set(self.app.remote_signatures()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Purely additive extension to `RemoteControllable` (from v1.6.0). `@app.remote` can't decorate methods in a class body because there's no live app/`self` at class-definition time, so methods had to be registered imperatively at runtime. This adds a class-body-friendly marker.

- **`remote_command`** (module-level decorator) — tags a method with the RPC name to expose it under (defaults to the method name). It only records `_remote_name` on the function and returns it unchanged; no registration happens at decoration time.
- **`RemoteControllable.register_remote_commands()`** — scans the class for tagged methods and registers each via the existing `self.remote(...)`. Returns the list of registered names.
- Exported `remote_command` from the package.

```python
from mytk import App, RemoteControllable, remote_command

class MyApp(App, RemoteControllable):
    @remote_command
    def turn_on(self): ...

    @remote_command(name="status")
    def read_status(self): return {"on": True}

app = MyApp(name="Server")
app.register_remote_commands()   # expose every tagged method
app.start_remote()
app.mainloop()
```

## Notes

- **Scanning reads markers off `type(self)` (the class), not the instance**, so it never invokes a `@property` getter as a side effect. A test asserts a raising property is left untouched during the scan.
- **Backward compatible:** existing `self.remote(...)` / `@app.remote` usage is unchanged; imperative and tagged registration coexist.

## Design decision (flagged, not silently chosen)

Should `start_remote()` auto-call `register_remote_commands()` so tagged methods "just work"?

**I kept it explicit** (recommended in the task): it mirrors how `remote()` is explicit and avoids surprising callers who register manually. If we later decide to auto-register inside `start_remote`, it's safe to do so — `remote()` overwrites by name, so re-registration is idempotent — but that's a follow-up choice, not made here.

## Tests

5 new tests in `testRemote.py`: bare `@remote_command` uses the method name, `@remote_command(name=...)` uses the custom name, end-to-end round-trip over a real `connect(...)` proxy (asserts a state change), `register_remote_commands()` returns the names without triggering property getters, and backward-compat with `@app.remote`. Full suite: 523 passed, 8 skipped.

Targeted for release **v1.6.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)