### PR TITLE
Rename the remote command-line client to `mytk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to myTk are documented here.
   other optional features, `zeroconf` is also installed on demand at first use
   of `advertise_remote()`; `discover()` imports it directly and raises a clear
   `ImportError` if missing (a client is often a plain script with no Tk root).
+- **The remote command-line client is now the `mytk` command**, replacing the
+  short-lived `mytk-remote` console script (introduced in 1.7.0, now removed —
+  use `mytk`, or `python -m mytk --remote`). Use it to probe, `--list`,
+  `--browse`, `--discover` and drive any RemoteControllable app.
 
 ## [1.7.1]
 ### Changed

--- a/mytk/remote.py
+++ b/mytk/remote.py
@@ -156,7 +156,7 @@ def browse(service_type=DEFAULT_SERVICE_TYPE, timeout=3.0):
 
     Unlike :func:`discover`, which connects to the first match, this collects
     every service seen within ``timeout`` and returns their addresses *without*
-    connecting, so a caller (or ``mytk-remote --browse``) can show what is
+    connecting, so a caller (or ``mytk --browse``) can show what is
     running::
 
         for server in mytk.browse():

--- a/mytk/remotecli.py
+++ b/mytk/remotecli.py
@@ -3,19 +3,19 @@
 Send a single call to a running app that exposed functions with
 :class:`~mytk.remotecontrollable.RemoteControllable` and print the result::
 
-    python -m mytk --remote "turn_on()"
+    mytk "add(2, 3)"                        # the `mytk` console script
+    mytk --app-name Acquisition "status()"
+    mytk --list                             # show the exposed functions
+    python -m mytk --remote "turn_on()"     # equivalent module form
     python -m mytk --remote "set_power(2.5)" --port 9000
-    mytk-remote "add(2, 3)"                  # standalone console script
-    mytk-remote --app-name Acquisition "status()"
-    mytk-remote --list                       # show the exposed functions
 
-Instead of a fixed ``--host``/``--port``, the server can be located on the
-local network via mDNS/Bonjour (as published by ``advertise_remote``)::
+Instead of a fixed ``--host``/``--port``, the server can be located on the local
+network via mDNS/Bonjour (as published by ``advertise_remote``)::
 
-    mytk-remote --discover "turn_on()"
-    mytk-remote --discover --app-name Microscope "status()"
-    mytk-remote --discover --list
-    mytk-remote --browse                     # list all apps on the network
+    mytk --discover "turn_on()"
+    mytk --discover --app-name Microscope "status()"
+    mytk --discover --list
+    mytk --browse                           # list all apps on the network
 
 Arguments in the call string must be Python literals (numbers, strings,
 True/False/None, lists, dicts, tuples); a bare ``"turn_on"`` is treated as
@@ -195,8 +195,8 @@ def run(argv=None, prog=None):
 
 
 def main():
-    """Console-script entry point (``mytk-remote``)."""
-    raise SystemExit(run(prog="mytk-remote"))
+    """Console-script entry point for the ``mytk`` command."""
+    raise SystemExit(run(prog="mytk"))
 
 
 if __name__ == "__main__":

--- a/mytk/remotecontrollable.py
+++ b/mytk/remotecontrollable.py
@@ -21,7 +21,7 @@ publishes them so external processes can call them::
     app.mainloop()
 
 Clients connect with ``mytk.connect(...)`` or ``mytk.remote_app`` (see
-:mod:`mytk.remote`), or from the command line with ``mytk-remote`` /
+:mod:`mytk.remote`), or from the command line with the ``mytk`` command /
 ``python -m mytk --remote`` (see :mod:`mytk.remotecli`). The transport is stdlib
 XML-RPC, so arguments and return values must be XML-RPC serializable (numbers,
 str, bool, None, list, dict).
@@ -218,7 +218,7 @@ class RemoteControllable:
 
         self.remote_server = server
         thread = threading.Thread(
-            target=server.serve_forever, name="mytk-remote", daemon=True
+            target=server.serve_forever, name="mytk-server", daemon=True
         )
         thread.start()
 

--- a/mytk/tests/testRemoteDiscovery.py
+++ b/mytk/tests/testRemoteDiscovery.py
@@ -190,7 +190,7 @@ class TestBrowse(unittest.TestCase):
 
 
 class TestRemoteCLIDiscovery(unittest.TestCase):
-    """`mytk-remote --discover` wiring, with discover() itself stubbed out."""
+    """`mytk --discover` wiring, with discover() itself stubbed out."""
 
     class FakeProxy:
         def remote_signatures(self):
@@ -203,7 +203,7 @@ class TestRemoteCLIDiscovery(unittest.TestCase):
         out = io.StringIO()
         err = io.StringIO()
         with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-            code = run(argv, prog="mytk-remote")
+            code = run(argv, prog="mytk")
         return code, out.getvalue(), err.getvalue()
 
     def test_discover_list(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 [project.scripts]
-mytk-remote = "mytk.remotecli:main"
+mytk = "mytk.remotecli:main"
 
 [project.urls]
 Homepage = "https://github.com/DCC-Lab/myTk"


### PR DESCRIPTION
Scoped to the general command-line tool only. Earlier downstream-app plumbing (`remote_cli`, `install_command_on_path`, `App.add_file_menu_command`) was removed.

## What this does

Renames the remote command-line client's console script from **`mytk-remote`** to **`mytk`** — the one general tool to probe, `--list`, `--browse`, `--discover`, and drive any `RemoteControllable` app.

The `mytk-remote` name (introduced in 1.7.0) is **dropped entirely — no compatibility alias**. All references (docstrings, the server thread name, tests) are updated so nothing points at the old name. `python -m mytk --remote` still works.

```bash
mytk "add(2, 3)"                 # call an exposed function
mytk --list                      # what does the app expose?
mytk --browse                    # what apps are on the network?
mytk --discover --app-name X "status()"
```

## Scope

- Command syntax, flags, discovery behavior, and exit codes are unchanged.
- 6 files: `pyproject.toml` (console script), `mytk/remotecli.py` (docstring + `main()`), `mytk/remote.py` + `mytk/remotecontrollable.py` (doc/thread-name references), `mytk/tests/testRemoteDiscovery.py` (test labels), `CHANGELOG.md`.
- No new public API, files, or dependencies. No new ruff violations.

## Compatibility

`mytk-remote` no longer exists (it shipped only in 1.7.0). Use `mytk` or `python -m mytk --remote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
